### PR TITLE
Texture Formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ FetchContent_MakeAvailable(VulkanHpp)
 add_library(Vex STATIC 
     
     src/Vex.h
- "src/Vex/GfxBackend.h" "src/Vex/GfxBackend.cpp" "src/Vex/Formats.h" "src/Vex/PlatformWindow.h" "src/Vex/Types.h" "src/Vex/UniqueHandle.h" "src/Vex/Logger.h" "src/Vex/Debug.h")
+ "src/Vex/GfxBackend.h" "src/Vex/GfxBackend.cpp" "src/Vex/Formats.h" "src/Vex/PlatformWindow.h" "src/Vex/Types.h" "src/Vex/UniqueHandle.h" "src/Vex/Logger.h" "src/Vex/Debug.h" )
 
 target_include_directories(Vex PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
@@ -102,13 +102,13 @@ target_include_directories(Vex PUBLIC
 
 # DX12 project files
 if (WIN32 AND VEX_ENABLE_DX12)
-    set(VEX_DX12_SOURCES
+    set(VEX_DX12_SOURCES "src/DX12/Formats.h"
     )
 endif()
 
 # Vulkan project files
 if (VEX_ENABLE_VULKAN AND Vulkan_FOUND)
-    set(VEX_VULKAN_SOURCES
+    set(VEX_VULKAN_SOURCES "src/Vulkan/Formats.h"
     )
 endif()
 

--- a/examples/example_hello_triangle/HelloTriangleApplication.cpp
+++ b/examples/example_hello_triangle/HelloTriangleApplication.cpp
@@ -25,8 +25,9 @@ HelloTriangleApplication::HelloTriangleApplication()
     int platformWindow = -1;
 #endif
     graphics = vex::CreateGraphicsBackend(
-        { .platformWindow = { .windowHandle = platformWindow, .width = DefaultWidth, .height = DefaultHeight },
-          .swapChainFormat = vex::Format::RGBA8_UNORM });
+        { .api = vex::GraphicsAPI::Vulkan,
+          .platformWindow = { .windowHandle = platformWindow, .width = DefaultWidth, .height = DefaultHeight },
+          .swapChainFormat = vex::TextureFormat::RGBA8_UNORM });
 }
 
 HelloTriangleApplication::~HelloTriangleApplication()

--- a/src/DX12/Formats.h
+++ b/src/DX12/Formats.h
@@ -1,0 +1,282 @@
+#pragma once
+
+#include <dxgiformat.h>
+
+#include <Vex/Formats.h>
+
+namespace vex::dx12
+{
+
+// Convert from TextureFormat to DXGI_FORMAT
+constexpr inline DXGI_FORMAT TextureFormatToDXGI(TextureFormat format)
+{
+    switch (format)
+    {
+    // Standard formats
+    case TextureFormat::R8_UNORM:
+        return DXGI_FORMAT_R8_UNORM;
+    case TextureFormat::R8_SNORM:
+        return DXGI_FORMAT_R8_SNORM;
+    case TextureFormat::R8_UINT:
+        return DXGI_FORMAT_R8_UINT;
+    case TextureFormat::R8_SINT:
+        return DXGI_FORMAT_R8_SINT;
+    case TextureFormat::RG8_UNORM:
+        return DXGI_FORMAT_R8G8_UNORM;
+    case TextureFormat::RG8_SNORM:
+        return DXGI_FORMAT_R8G8_SNORM;
+    case TextureFormat::RG8_UINT:
+        return DXGI_FORMAT_R8G8_UINT;
+    case TextureFormat::RG8_SINT:
+        return DXGI_FORMAT_R8G8_SINT;
+    case TextureFormat::RGBA8_UNORM:
+        return DXGI_FORMAT_R8G8B8A8_UNORM;
+    case TextureFormat::RGBA8_UNORM_SRGB:
+        return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    case TextureFormat::RGBA8_SNORM:
+        return DXGI_FORMAT_R8G8B8A8_SNORM;
+    case TextureFormat::RGBA8_UINT:
+        return DXGI_FORMAT_R8G8B8A8_UINT;
+    case TextureFormat::RGBA8_SINT:
+        return DXGI_FORMAT_R8G8B8A8_SINT;
+    case TextureFormat::BGRA8_UNORM:
+        return DXGI_FORMAT_B8G8R8A8_UNORM;
+    case TextureFormat::BGRA8_UNORM_SRGB:
+        return DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
+
+    // 16-bit formats
+    case TextureFormat::R16_UINT:
+        return DXGI_FORMAT_R16_UINT;
+    case TextureFormat::R16_SINT:
+        return DXGI_FORMAT_R16_SINT;
+    case TextureFormat::R16_FLOAT:
+        return DXGI_FORMAT_R16_FLOAT;
+    case TextureFormat::RG16_UINT:
+        return DXGI_FORMAT_R16G16_UINT;
+    case TextureFormat::RG16_SINT:
+        return DXGI_FORMAT_R16G16_SINT;
+    case TextureFormat::RG16_FLOAT:
+        return DXGI_FORMAT_R16G16_FLOAT;
+    case TextureFormat::RGBA16_UINT:
+        return DXGI_FORMAT_R16G16B16A16_UINT;
+    case TextureFormat::RGBA16_SINT:
+        return DXGI_FORMAT_R16G16B16A16_SINT;
+    case TextureFormat::RGBA16_FLOAT:
+        return DXGI_FORMAT_R16G16B16A16_FLOAT;
+
+    // 32-bit formats
+    case TextureFormat::R32_UINT:
+        return DXGI_FORMAT_R32_UINT;
+    case TextureFormat::R32_SINT:
+        return DXGI_FORMAT_R32_SINT;
+    case TextureFormat::R32_FLOAT:
+        return DXGI_FORMAT_R32_FLOAT;
+    case TextureFormat::RG32_UINT:
+        return DXGI_FORMAT_R32G32_UINT;
+    case TextureFormat::RG32_SINT:
+        return DXGI_FORMAT_R32G32_SINT;
+    case TextureFormat::RG32_FLOAT:
+        return DXGI_FORMAT_R32G32_FLOAT;
+    case TextureFormat::RGB32_UINT:
+        return DXGI_FORMAT_R32G32B32_UINT;
+    case TextureFormat::RGB32_SINT:
+        return DXGI_FORMAT_R32G32B32_SINT;
+    case TextureFormat::RGB32_FLOAT:
+        return DXGI_FORMAT_R32G32B32_FLOAT;
+    case TextureFormat::RGBA32_UINT:
+        return DXGI_FORMAT_R32G32B32A32_UINT;
+    case TextureFormat::RGBA32_SINT:
+        return DXGI_FORMAT_R32G32B32A32_SINT;
+    case TextureFormat::RGBA32_FLOAT:
+        return DXGI_FORMAT_R32G32B32A32_FLOAT;
+
+    // Packed formats
+    case TextureFormat::RGB10A2_UNORM:
+        return DXGI_FORMAT_R10G10B10A2_UNORM;
+    case TextureFormat::RGB10A2_UINT:
+        return DXGI_FORMAT_R10G10B10A2_UINT;
+    case TextureFormat::RG11B10_FLOAT:
+        return DXGI_FORMAT_R11G11B10_FLOAT;
+
+    // Depth/stencil formats
+    case TextureFormat::D16_UNORM:
+        return DXGI_FORMAT_D16_UNORM;
+    case TextureFormat::D24_UNORM_S8_UINT:
+        return DXGI_FORMAT_D24_UNORM_S8_UINT;
+    case TextureFormat::D32_FLOAT:
+        return DXGI_FORMAT_D32_FLOAT;
+    case TextureFormat::D32_FLOAT_S8_UINT:
+        return DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+
+    // BC compressed formats
+    case TextureFormat::BC1_UNORM:
+        return DXGI_FORMAT_BC1_UNORM;
+    case TextureFormat::BC1_UNORM_SRGB:
+        return DXGI_FORMAT_BC1_UNORM_SRGB;
+    case TextureFormat::BC2_UNORM:
+        return DXGI_FORMAT_BC2_UNORM;
+    case TextureFormat::BC2_UNORM_SRGB:
+        return DXGI_FORMAT_BC2_UNORM_SRGB;
+    case TextureFormat::BC3_UNORM:
+        return DXGI_FORMAT_BC3_UNORM;
+    case TextureFormat::BC3_UNORM_SRGB:
+        return DXGI_FORMAT_BC3_UNORM_SRGB;
+    case TextureFormat::BC4_UNORM:
+        return DXGI_FORMAT_BC4_UNORM;
+    case TextureFormat::BC4_SNORM:
+        return DXGI_FORMAT_BC4_SNORM;
+    case TextureFormat::BC5_UNORM:
+        return DXGI_FORMAT_BC5_UNORM;
+    case TextureFormat::BC5_SNORM:
+        return DXGI_FORMAT_BC5_SNORM;
+    case TextureFormat::BC6H_UF16:
+        return DXGI_FORMAT_BC6H_UF16;
+    case TextureFormat::BC6H_SF16:
+        return DXGI_FORMAT_BC6H_SF16;
+    case TextureFormat::BC7_UNORM:
+        return DXGI_FORMAT_BC7_UNORM;
+    case TextureFormat::BC7_UNORM_SRGB:
+        return DXGI_FORMAT_BC7_UNORM_SRGB;
+
+    default:
+        return DXGI_FORMAT_UNKNOWN;
+    }
+}
+
+// Convert from DXGI_FORMAT to TextureFormat
+constexpr inline TextureFormat DXGIToTextureFormat(DXGI_FORMAT format)
+{
+    switch (format)
+    {
+    // Standard formats
+    case DXGI_FORMAT_R8_UNORM:
+        return TextureFormat::R8_UNORM;
+    case DXGI_FORMAT_R8_SNORM:
+        return TextureFormat::R8_SNORM;
+    case DXGI_FORMAT_R8_UINT:
+        return TextureFormat::R8_UINT;
+    case DXGI_FORMAT_R8_SINT:
+        return TextureFormat::R8_SINT;
+    case DXGI_FORMAT_R8G8_UNORM:
+        return TextureFormat::RG8_UNORM;
+    case DXGI_FORMAT_R8G8_SNORM:
+        return TextureFormat::RG8_SNORM;
+    case DXGI_FORMAT_R8G8_UINT:
+        return TextureFormat::RG8_UINT;
+    case DXGI_FORMAT_R8G8_SINT:
+        return TextureFormat::RG8_SINT;
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+        return TextureFormat::RGBA8_UNORM;
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        return TextureFormat::RGBA8_UNORM_SRGB;
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+        return TextureFormat::RGBA8_SNORM;
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+        return TextureFormat::RGBA8_UINT;
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+        return TextureFormat::RGBA8_SINT;
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+        return TextureFormat::BGRA8_UNORM;
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        return TextureFormat::BGRA8_UNORM_SRGB;
+
+    // 16-bit formats
+    case DXGI_FORMAT_R16_UINT:
+        return TextureFormat::R16_UINT;
+    case DXGI_FORMAT_R16_SINT:
+        return TextureFormat::R16_SINT;
+    case DXGI_FORMAT_R16_FLOAT:
+        return TextureFormat::R16_FLOAT;
+    case DXGI_FORMAT_R16G16_UINT:
+        return TextureFormat::RG16_UINT;
+    case DXGI_FORMAT_R16G16_SINT:
+        return TextureFormat::RG16_SINT;
+    case DXGI_FORMAT_R16G16_FLOAT:
+        return TextureFormat::RG16_FLOAT;
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+        return TextureFormat::RGBA16_UINT;
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+        return TextureFormat::RGBA16_SINT;
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        return TextureFormat::RGBA16_FLOAT;
+
+    // 32-bit formats
+    case DXGI_FORMAT_R32_UINT:
+        return TextureFormat::R32_UINT;
+    case DXGI_FORMAT_R32_SINT:
+        return TextureFormat::R32_SINT;
+    case DXGI_FORMAT_R32_FLOAT:
+        return TextureFormat::R32_FLOAT;
+    case DXGI_FORMAT_R32G32_UINT:
+        return TextureFormat::RG32_UINT;
+    case DXGI_FORMAT_R32G32_SINT:
+        return TextureFormat::RG32_SINT;
+    case DXGI_FORMAT_R32G32_FLOAT:
+        return TextureFormat::RG32_FLOAT;
+    case DXGI_FORMAT_R32G32B32_UINT:
+        return TextureFormat::RGB32_UINT;
+    case DXGI_FORMAT_R32G32B32_SINT:
+        return TextureFormat::RGB32_SINT;
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+        return TextureFormat::RGB32_FLOAT;
+    case DXGI_FORMAT_R32G32B32A32_UINT:
+        return TextureFormat::RGBA32_UINT;
+    case DXGI_FORMAT_R32G32B32A32_SINT:
+        return TextureFormat::RGBA32_SINT;
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        return TextureFormat::RGBA32_FLOAT;
+
+    // Packed formats
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+        return TextureFormat::RGB10A2_UNORM;
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+        return TextureFormat::RGB10A2_UINT;
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+        return TextureFormat::RG11B10_FLOAT;
+
+    // Depth/stencil formats
+    case DXGI_FORMAT_D16_UNORM:
+        return TextureFormat::D16_UNORM;
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        return TextureFormat::D24_UNORM_S8_UINT;
+    case DXGI_FORMAT_D32_FLOAT:
+        return TextureFormat::D32_FLOAT;
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        return TextureFormat::D32_FLOAT_S8_UINT;
+
+    // BC compressed formats
+    case DXGI_FORMAT_BC1_UNORM:
+        return TextureFormat::BC1_UNORM;
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+        return TextureFormat::BC1_UNORM_SRGB;
+    case DXGI_FORMAT_BC2_UNORM:
+        return TextureFormat::BC2_UNORM;
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+        return TextureFormat::BC2_UNORM_SRGB;
+    case DXGI_FORMAT_BC3_UNORM:
+        return TextureFormat::BC3_UNORM;
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+        return TextureFormat::BC3_UNORM_SRGB;
+    case DXGI_FORMAT_BC4_UNORM:
+        return TextureFormat::BC4_UNORM;
+    case DXGI_FORMAT_BC4_SNORM:
+        return TextureFormat::BC4_SNORM;
+    case DXGI_FORMAT_BC5_UNORM:
+        return TextureFormat::BC5_UNORM;
+    case DXGI_FORMAT_BC5_SNORM:
+        return TextureFormat::BC5_SNORM;
+    case DXGI_FORMAT_BC6H_UF16:
+        return TextureFormat::BC6H_UF16;
+    case DXGI_FORMAT_BC6H_SF16:
+        return TextureFormat::BC6H_SF16;
+    case DXGI_FORMAT_BC7_UNORM:
+        return TextureFormat::BC7_UNORM;
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        return TextureFormat::BC7_UNORM_SRGB;
+
+    default:
+        return TextureFormat::UNKNOWN;
+    }
+}
+
+} // namespace vex::dx12

--- a/src/Vex/Formats.h
+++ b/src/Vex/Formats.h
@@ -5,10 +5,79 @@
 namespace vex
 {
 
-enum class Format : u8
+enum class TextureFormat : u8
 {
+    // Standard formats
+    R8_UNORM,
+    R8_SNORM,
+    R8_UINT,
+    R8_SINT,
+    RG8_UNORM,
+    RG8_SNORM,
+    RG8_UINT,
+    RG8_SINT,
     RGBA8_UNORM,
+    RGBA8_UNORM_SRGB,
+    RGBA8_SNORM,
+    RGBA8_UINT,
+    RGBA8_SINT,
+    BGRA8_UNORM,
+    BGRA8_UNORM_SRGB,
+
+    // 16-bit formats
+    R16_UINT,
+    R16_SINT,
+    R16_FLOAT,
+    RG16_UINT,
+    RG16_SINT,
+    RG16_FLOAT,
+    RGBA16_UINT,
+    RGBA16_SINT,
     RGBA16_FLOAT,
+
+    // 32-bit formats
+    R32_UINT,
+    R32_SINT,
+    R32_FLOAT,
+    RG32_UINT,
+    RG32_SINT,
+    RG32_FLOAT,
+    RGB32_UINT,
+    RGB32_SINT,
+    RGB32_FLOAT,
+    RGBA32_UINT,
+    RGBA32_SINT,
+    RGBA32_FLOAT,
+
+    // Packed formats
+    RGB10A2_UNORM,
+    RGB10A2_UINT,
+    RG11B10_FLOAT,
+
+    // Depth/stencil formats
+    D16_UNORM,
+    D24_UNORM_S8_UINT,
+    D32_FLOAT,
+    D32_FLOAT_S8_UINT,
+
+    // BC compressed formats
+    BC1_UNORM,
+    BC1_UNORM_SRGB,
+    BC2_UNORM,
+    BC2_UNORM_SRGB,
+    BC3_UNORM,
+    BC3_UNORM_SRGB,
+    BC4_UNORM,
+    BC4_SNORM,
+    BC5_UNORM,
+    BC5_SNORM,
+    BC6H_UF16,
+    BC6H_SF16,
+    BC7_UNORM,
+    BC7_UNORM_SRGB,
+
+    // Error format
+    UNKNOWN,
 };
 
 } // namespace vex

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -7,10 +7,17 @@
 namespace vex
 {
 
+enum class GraphicsAPI : u8
+{
+    DirectX12,
+    Vulkan
+};
+
 struct BackendDescription
 {
+    GraphicsAPI api;
     PlatformWindow platformWindow;
-    Format swapChainFormat;
+    TextureFormat swapChainFormat;
 };
 
 class GfxBackend

--- a/src/Vulkan/Formats.h
+++ b/src/Vulkan/Formats.h
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <utility>
+
+#include <Vex/Formats.h>
+
+namespace vex::vk
+{
+
+// Certain formats require special care because they differ from DX12 to Vulkan in terms of component ordering.
+// This method returns true if the format has ordering different to what is found in vex::TextureFormat.
+constexpr inline bool IsSpecialFormat(VkFormat format)
+{
+    // Packed formats
+    switch (format)
+    {
+    case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+    case VK_FORMAT_A2R10G10B10_UINT_PACK32:
+    case VK_FORMAT_B10G11R11_UFLOAT_PACK32:
+        return true;
+    default:
+        return false;
+    }
+    std::unreachable();
+}
+
+// Convert from TextureFormat to VkFormat
+constexpr inline VkFormat TextureFormatToVulkan(TextureFormat format)
+{
+    switch (format)
+    {
+    // Standard formats
+    case TextureFormat::R8_UNORM:
+        return VK_FORMAT_R8_UNORM;
+    case TextureFormat::R8_SNORM:
+        return VK_FORMAT_R8_SNORM;
+    case TextureFormat::R8_UINT:
+        return VK_FORMAT_R8_UINT;
+    case TextureFormat::R8_SINT:
+        return VK_FORMAT_R8_SINT;
+    case TextureFormat::RG8_UNORM:
+        return VK_FORMAT_R8G8_UNORM;
+    case TextureFormat::RG8_SNORM:
+        return VK_FORMAT_R8G8_SNORM;
+    case TextureFormat::RG8_UINT:
+        return VK_FORMAT_R8G8_UINT;
+    case TextureFormat::RG8_SINT:
+        return VK_FORMAT_R8G8_SINT;
+    case TextureFormat::RGBA8_UNORM:
+        return VK_FORMAT_R8G8B8A8_UNORM;
+    case TextureFormat::RGBA8_UNORM_SRGB:
+        return VK_FORMAT_R8G8B8A8_SRGB;
+    case TextureFormat::RGBA8_SNORM:
+        return VK_FORMAT_R8G8B8A8_SNORM;
+    case TextureFormat::RGBA8_UINT:
+        return VK_FORMAT_R8G8B8A8_UINT;
+    case TextureFormat::RGBA8_SINT:
+        return VK_FORMAT_R8G8B8A8_SINT;
+    case TextureFormat::BGRA8_UNORM:
+        return VK_FORMAT_B8G8R8A8_UNORM;
+    case TextureFormat::BGRA8_UNORM_SRGB:
+        return VK_FORMAT_B8G8R8A8_SRGB;
+
+    // 16-bit formats
+    case TextureFormat::R16_UINT:
+        return VK_FORMAT_R16_UINT;
+    case TextureFormat::R16_SINT:
+        return VK_FORMAT_R16_SINT;
+    case TextureFormat::R16_FLOAT:
+        return VK_FORMAT_R16_SFLOAT;
+    case TextureFormat::RG16_UINT:
+        return VK_FORMAT_R16G16_UINT;
+    case TextureFormat::RG16_SINT:
+        return VK_FORMAT_R16G16_SINT;
+    case TextureFormat::RG16_FLOAT:
+        return VK_FORMAT_R16G16_SFLOAT;
+    case TextureFormat::RGBA16_UINT:
+        return VK_FORMAT_R16G16B16A16_UINT;
+    case TextureFormat::RGBA16_SINT:
+        return VK_FORMAT_R16G16B16A16_SINT;
+    case TextureFormat::RGBA16_FLOAT:
+        return VK_FORMAT_R16G16B16A16_SFLOAT;
+
+    // 32-bit formats
+    case TextureFormat::R32_UINT:
+        return VK_FORMAT_R32_UINT;
+    case TextureFormat::R32_SINT:
+        return VK_FORMAT_R32_SINT;
+    case TextureFormat::R32_FLOAT:
+        return VK_FORMAT_R32_SFLOAT;
+    case TextureFormat::RG32_UINT:
+        return VK_FORMAT_R32G32_UINT;
+    case TextureFormat::RG32_SINT:
+        return VK_FORMAT_R32G32_SINT;
+    case TextureFormat::RG32_FLOAT:
+        return VK_FORMAT_R32G32_SFLOAT;
+    case TextureFormat::RGB32_UINT:
+        return VK_FORMAT_R32G32B32_UINT;
+    case TextureFormat::RGB32_SINT:
+        return VK_FORMAT_R32G32B32_SINT;
+    case TextureFormat::RGB32_FLOAT:
+        return VK_FORMAT_R32G32B32_SFLOAT;
+    case TextureFormat::RGBA32_UINT:
+        return VK_FORMAT_R32G32B32A32_UINT;
+    case TextureFormat::RGBA32_SINT:
+        return VK_FORMAT_R32G32B32A32_SINT;
+    case TextureFormat::RGBA32_FLOAT:
+        return VK_FORMAT_R32G32B32A32_SFLOAT;
+
+    // Packed formats
+    case TextureFormat::RGB10A2_UNORM:
+        return VK_FORMAT_A2R10G10B10_UNORM_PACK32; // Note format difference
+    case TextureFormat::RGB10A2_UINT:
+        return VK_FORMAT_A2R10G10B10_UINT_PACK32; // Note format difference
+    case TextureFormat::RG11B10_FLOAT:
+        return VK_FORMAT_B10G11R11_UFLOAT_PACK32; // Note format difference
+
+    // Depth/stencil formats
+    case TextureFormat::D16_UNORM:
+        return VK_FORMAT_D16_UNORM;
+    case TextureFormat::D24_UNORM_S8_UINT:
+        return VK_FORMAT_D24_UNORM_S8_UINT;
+    case TextureFormat::D32_FLOAT:
+        return VK_FORMAT_D32_SFLOAT;
+    case TextureFormat::D32_FLOAT_S8_UINT:
+        return VK_FORMAT_D32_SFLOAT_S8_UINT;
+
+    // BC compressed formats
+    case TextureFormat::BC1_UNORM:
+        return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+    case TextureFormat::BC1_UNORM_SRGB:
+        return VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
+    case TextureFormat::BC2_UNORM:
+        return VK_FORMAT_BC2_UNORM_BLOCK;
+    case TextureFormat::BC2_UNORM_SRGB:
+        return VK_FORMAT_BC2_SRGB_BLOCK;
+    case TextureFormat::BC3_UNORM:
+        return VK_FORMAT_BC3_UNORM_BLOCK;
+    case TextureFormat::BC3_UNORM_SRGB:
+        return VK_FORMAT_BC3_SRGB_BLOCK;
+    case TextureFormat::BC4_UNORM:
+        return VK_FORMAT_BC4_UNORM_BLOCK;
+    case TextureFormat::BC4_SNORM:
+        return VK_FORMAT_BC4_SNORM_BLOCK;
+    case TextureFormat::BC5_UNORM:
+        return VK_FORMAT_BC5_UNORM_BLOCK;
+    case TextureFormat::BC5_SNORM:
+        return VK_FORMAT_BC5_SNORM_BLOCK;
+    case TextureFormat::BC6H_UF16:
+        return VK_FORMAT_BC6H_UFLOAT_BLOCK;
+    case TextureFormat::BC6H_SF16:
+        return VK_FORMAT_BC6H_SFLOAT_BLOCK;
+    case TextureFormat::BC7_UNORM:
+        return VK_FORMAT_BC7_UNORM_BLOCK;
+    case TextureFormat::BC7_UNORM_SRGB:
+        return VK_FORMAT_BC7_SRGB_BLOCK;
+
+    default:
+        return VK_FORMAT_UNDEFINED;
+    }
+}
+
+// Convert from VkFormat to TextureFormat
+constexpr inline TextureFormat VulkanToTextureFormat(VkFormat format)
+{
+    switch (format)
+    {
+    // Standard formats
+    case VK_FORMAT_R8_UNORM:
+        return TextureFormat::R8_UNORM;
+    case VK_FORMAT_R8_SNORM:
+        return TextureFormat::R8_SNORM;
+    case VK_FORMAT_R8_UINT:
+        return TextureFormat::R8_UINT;
+    case VK_FORMAT_R8_SINT:
+        return TextureFormat::R8_SINT;
+    case VK_FORMAT_R8G8_UNORM:
+        return TextureFormat::RG8_UNORM;
+    case VK_FORMAT_R8G8_SNORM:
+        return TextureFormat::RG8_SNORM;
+    case VK_FORMAT_R8G8_UINT:
+        return TextureFormat::RG8_UINT;
+    case VK_FORMAT_R8G8_SINT:
+        return TextureFormat::RG8_SINT;
+    case VK_FORMAT_R8G8B8A8_UNORM:
+        return TextureFormat::RGBA8_UNORM;
+    case VK_FORMAT_R8G8B8A8_SRGB:
+        return TextureFormat::RGBA8_UNORM_SRGB;
+    case VK_FORMAT_R8G8B8A8_SNORM:
+        return TextureFormat::RGBA8_SNORM;
+    case VK_FORMAT_R8G8B8A8_UINT:
+        return TextureFormat::RGBA8_UINT;
+    case VK_FORMAT_R8G8B8A8_SINT:
+        return TextureFormat::RGBA8_SINT;
+    case VK_FORMAT_B8G8R8A8_UNORM:
+        return TextureFormat::BGRA8_UNORM;
+    case VK_FORMAT_B8G8R8A8_SRGB:
+        return TextureFormat::BGRA8_UNORM_SRGB;
+
+    // 16-bit formats
+    case VK_FORMAT_R16_UINT:
+        return TextureFormat::R16_UINT;
+    case VK_FORMAT_R16_SINT:
+        return TextureFormat::R16_SINT;
+    case VK_FORMAT_R16_SFLOAT:
+        return TextureFormat::R16_FLOAT;
+    case VK_FORMAT_R16G16_UINT:
+        return TextureFormat::RG16_UINT;
+    case VK_FORMAT_R16G16_SINT:
+        return TextureFormat::RG16_SINT;
+    case VK_FORMAT_R16G16_SFLOAT:
+        return TextureFormat::RG16_FLOAT;
+    case VK_FORMAT_R16G16B16A16_UINT:
+        return TextureFormat::RGBA16_UINT;
+    case VK_FORMAT_R16G16B16A16_SINT:
+        return TextureFormat::RGBA16_SINT;
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
+        return TextureFormat::RGBA16_FLOAT;
+
+    // 32-bit formats
+    case VK_FORMAT_R32_UINT:
+        return TextureFormat::R32_UINT;
+    case VK_FORMAT_R32_SINT:
+        return TextureFormat::R32_SINT;
+    case VK_FORMAT_R32_SFLOAT:
+        return TextureFormat::R32_FLOAT;
+    case VK_FORMAT_R32G32_UINT:
+        return TextureFormat::RG32_UINT;
+    case VK_FORMAT_R32G32_SINT:
+        return TextureFormat::RG32_SINT;
+    case VK_FORMAT_R32G32_SFLOAT:
+        return TextureFormat::RG32_FLOAT;
+    case VK_FORMAT_R32G32B32_UINT:
+        return TextureFormat::RGB32_UINT;
+    case VK_FORMAT_R32G32B32_SINT:
+        return TextureFormat::RGB32_SINT;
+    case VK_FORMAT_R32G32B32_SFLOAT:
+        return TextureFormat::RGB32_FLOAT;
+    case VK_FORMAT_R32G32B32A32_UINT:
+        return TextureFormat::RGBA32_UINT;
+    case VK_FORMAT_R32G32B32A32_SINT:
+        return TextureFormat::RGBA32_SINT;
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+        return TextureFormat::RGBA32_FLOAT;
+
+    // Packed formats
+    case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+        return TextureFormat::RGB10A2_UNORM; // Note format difference
+    case VK_FORMAT_A2R10G10B10_UINT_PACK32:
+        return TextureFormat::RGB10A2_UINT; // Note format difference
+    case VK_FORMAT_B10G11R11_UFLOAT_PACK32:
+        return TextureFormat::RG11B10_FLOAT; // Note format difference
+
+    // Depth/stencil formats
+    case VK_FORMAT_D16_UNORM:
+        return TextureFormat::D16_UNORM;
+    case VK_FORMAT_D24_UNORM_S8_UINT:
+        return TextureFormat::D24_UNORM_S8_UINT;
+    case VK_FORMAT_D32_SFLOAT:
+        return TextureFormat::D32_FLOAT;
+    case VK_FORMAT_D32_SFLOAT_S8_UINT:
+        return TextureFormat::D32_FLOAT_S8_UINT;
+
+    // BC compressed formats
+    case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
+        return TextureFormat::BC1_UNORM;
+    case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
+        return TextureFormat::BC1_UNORM_SRGB;
+    case VK_FORMAT_BC2_UNORM_BLOCK:
+        return TextureFormat::BC2_UNORM;
+    case VK_FORMAT_BC2_SRGB_BLOCK:
+        return TextureFormat::BC2_UNORM_SRGB;
+    case VK_FORMAT_BC3_UNORM_BLOCK:
+        return TextureFormat::BC3_UNORM;
+    case VK_FORMAT_BC3_SRGB_BLOCK:
+        return TextureFormat::BC3_UNORM_SRGB;
+    case VK_FORMAT_BC4_UNORM_BLOCK:
+        return TextureFormat::BC4_UNORM;
+    case VK_FORMAT_BC4_SNORM_BLOCK:
+        return TextureFormat::BC4_SNORM;
+    case VK_FORMAT_BC5_UNORM_BLOCK:
+        return TextureFormat::BC5_UNORM;
+    case VK_FORMAT_BC5_SNORM_BLOCK:
+        return TextureFormat::BC5_SNORM;
+    case VK_FORMAT_BC6H_UFLOAT_BLOCK:
+        return TextureFormat::BC6H_UF16;
+    case VK_FORMAT_BC6H_SFLOAT_BLOCK:
+        return TextureFormat::BC6H_SF16;
+    case VK_FORMAT_BC7_UNORM_BLOCK:
+        return TextureFormat::BC7_UNORM;
+    case VK_FORMAT_BC7_SRGB_BLOCK:
+        return TextureFormat::BC7_UNORM_SRGB;
+
+    default:
+        return TextureFormat::UNKNOWN;
+    }
+}
+
+} // namespace vex::vk


### PR DESCRIPTION
- Adds Vex texture formats and api-specific conversion methods
- Handles the few formats that differ between DX12 and Vk