### PR TITLE
Swapchain Creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,14 @@ add_library(Vex STATIC
     "src/Vex/RHI/RHIFence.h"
     "src/Vex/RHI/RHIFence.cpp"
     "src/Vex/FrameResource.h"
-
-)
+    "src/Vex/RHI/RHISwapChain.h"
+    "src/Vex/RHI/RHITexture.h"
+    "src/Vex/Formats.cpp"
+    "src/Vex/RHI/RHIBuffer.h"
+    "src/Vex/Texture.h"
+    "src/Vex/Buffer.h"
+    "src/Vex/CommandQueueType.h"
+ "src/Vex/RHI/RHIFwd.h")
 
 if (WIN32)
     target_sources(Vex PRIVATE
@@ -179,7 +185,14 @@ if (WIN32 AND VEX_ENABLE_DX12)
         "src/DX12/DX12Fence.h"
         "src/DX12/DX12Fence.cpp"
         "src/DX12/DX12CommandPool.h"
-     "src/DX12/DX12CommandPool.cpp" "src/DX12/DX12CommandList.h" "src/DX12/DX12CommandList.cpp")
+        "src/DX12/DX12CommandPool.cpp"
+        "src/DX12/DX12CommandList.h"
+        "src/DX12/DX12CommandList.cpp"
+        "src/DX12/DX12SwapChain.h"
+        "src/DX12/DX12SwapChain.cpp"
+        "src/DX12/DX12Texture.h"
+        "src/DX12/DX12Texture.cpp"
+    )
 endif()
 
 # Vulkan project files
@@ -205,6 +218,8 @@ if (VEX_ENABLE_VULKAN AND Vulkan_FOUND)
         "src/Vulkan/VkCommandList.h"
         "src/Vulkan/Synchro/VkFence.cpp"
         "src/Vulkan/Synchro/VkFence.h"
+        "src/Vulkan/VkSwapChain.h"
+        "src/Vulkan/VkSwapChain.cpp"
     )
 endif()
 

--- a/examples/example_hello_triangle/HelloTriangleApplication.cpp
+++ b/examples/example_hello_triangle/HelloTriangleApplication.cpp
@@ -39,7 +39,7 @@ HelloTriangleApplication::HelloTriangleApplication()
     vex::PlatformWindowHandle platformWindow{ .window = glfwGetX11Window(window), .display = glfwGetX11Display() };
 #endif
 
-#define FORCE_VULKAN 1
+#define FORCE_VULKAN 0
 
     graphics = CreateGraphicsBackend(
 #if VEX_VULKAN and FORCE_VULKAN

--- a/src/DX12/DX12RHI.cpp
+++ b/src/DX12/DX12RHI.cpp
@@ -7,6 +7,7 @@
 #include <DX12/DX12Debug.h>
 #include <DX12/DX12Fence.h>
 #include <DX12/DX12PhysicalDevice.h>
+#include <DX12/DX12SwapChain.h>
 #include <DX12/DXGIFactory.h>
 #include <DX12/HRChecker.h>
 
@@ -105,6 +106,12 @@ void DX12RHI::Init(const UniqueHandle<PhysicalDevice>& physicalDevice)
                                        .NodeMask = 0 };
         chk << device->CreateCommandQueue(&desc, IID_PPV_ARGS(&GetQueue(CommandQueueType::Copy)));
     }
+}
+
+UniqueHandle<RHISwapChain> DX12RHI::CreateSwapChain(const SwapChainDescription& description,
+                                                    const PlatformWindow& platformWindow)
+{
+    return MakeUnique<DX12SwapChain>(device, description, GetQueue(CommandQueueType::Graphics), platformWindow);
 }
 
 UniqueHandle<RHICommandPool> DX12RHI::CreateCommandPool()

--- a/src/DX12/DX12RHI.h
+++ b/src/DX12/DX12RHI.h
@@ -23,6 +23,9 @@ public:
     virtual std::vector<UniqueHandle<PhysicalDevice>> EnumeratePhysicalDevices() override;
     virtual void Init(const UniqueHandle<PhysicalDevice>& physicalDevice) override;
 
+    virtual UniqueHandle<RHISwapChain> CreateSwapChain(const SwapChainDescription& description,
+                                                       const PlatformWindow& platformWindow) override;
+
     virtual UniqueHandle<RHICommandPool> CreateCommandPool() override;
 
     virtual void ExecuteCommandList(RHICommandList& commandList) override;

--- a/src/DX12/DX12SwapChain.cpp
+++ b/src/DX12/DX12SwapChain.cpp
@@ -1,0 +1,95 @@
+#include "DX12SwapChain.h"
+
+#include <Vex/Logger.h>
+#include <Vex/PlatformWindow.h>
+
+#include <DX12/DX12Formats.h>
+#include <DX12/DX12Texture.h>
+#include <DX12/DXGIFactory.h>
+#include <DX12/HRChecker.h>
+
+namespace vex::dx12
+{
+
+DX12SwapChain::DX12SwapChain(const ComPtr<DX12Device>& device,
+                             SwapChainDescription desc,
+                             const ComPtr<ID3D12CommandQueue>& commandQueue,
+                             const PlatformWindow& platformWindow)
+    : description(std::move(desc))
+{
+    auto ValidateFlipModelSupportedFormats = [](DXGI_FORMAT format)
+    {
+        return format == DXGI_FORMAT_R16G16B16A16_FLOAT || format == DXGI_FORMAT_B8G8R8A8_UNORM ||
+               format == DXGI_FORMAT_R8G8B8A8_UNORM || format == DXGI_FORMAT_R10G10B10A2_UNORM;
+    };
+
+    DXGI_FORMAT nativeFormat = TextureFormatToDXGI(description.format);
+    if (!ValidateFlipModelSupportedFormats(nativeFormat))
+    {
+        VEX_LOG(Fatal, "Invalid swapchain format for the _FLIP_ swap mode.");
+        return;
+    }
+
+    DXGI_SWAP_CHAIN_DESC1 nativeSwapChainDesc{
+        .Width = platformWindow.width,
+        .Height = platformWindow.height,
+        .Format = nativeFormat,
+        .Stereo = false,
+        .SampleDesc = { .Count = 1, .Quality = 0 },
+        .BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
+        .BufferCount = GetBackBufferCount(description.frameBuffering),
+        .Scaling = DXGI_SCALING_STRETCH,
+        .SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
+        .AlphaMode = DXGI_ALPHA_MODE_IGNORE,
+        .Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING,
+    };
+    swapChain = DXGIFactory::CreateSwapChain(nativeSwapChainDesc, commandQueue, platformWindow.windowHandle.window);
+    ExtractBackBuffers();
+}
+
+DX12SwapChain::~DX12SwapChain()
+{
+}
+
+void DX12SwapChain::Present()
+{
+    chk << swapChain->Present(description.useVSync, !description.useVSync ? DXGI_PRESENT_ALLOW_TEARING : 0);
+}
+
+void DX12SwapChain::Resize(u32 width, u32 height)
+{
+    backBuffers.clear();
+    chk << swapChain->ResizeBuffers(GetBackBufferCount(description.frameBuffering),
+                                    width,
+                                    height,
+                                    TextureFormatToDXGI(description.format),
+                                    DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
+    ExtractBackBuffers();
+}
+
+void DX12SwapChain::SetVSync(bool enableVSync)
+{
+    description.useVSync = enableVSync;
+}
+
+RHITexture* DX12SwapChain::GetBackBuffer(u8 backBufferIndex)
+{
+    return backBuffers[backBufferIndex].get();
+}
+
+void DX12SwapChain::ExtractBackBuffers()
+{
+    for (u32 backBufferIndex = 0; backBufferIndex < GetBackBufferCount(description.frameBuffering); ++backBufferIndex)
+    {
+        ComPtr<ID3D12Resource> backBuffer;
+        chk << swapChain->GetBuffer(backBufferIndex, IID_PPV_ARGS(&backBuffer));
+        backBuffers.emplace_back(new DX12Texture(std::format("BackBuffer_{}", backBufferIndex), backBuffer));
+    }
+}
+
+u8 DX12SwapChain::GetBackBufferCount(FrameBuffering frameBuffering)
+{
+    return std::max<u8>(2, std::to_underlying(frameBuffering));
+}
+
+} // namespace vex::dx12

--- a/src/DX12/DX12SwapChain.cpp
+++ b/src/DX12/DX12SwapChain.cpp
@@ -72,6 +72,11 @@ void DX12SwapChain::SetVSync(bool enableVSync)
     description.useVSync = enableVSync;
 }
 
+bool DX12SwapChain::NeedsFlushForVSyncToggle()
+{
+    return false;
+}
+
 RHITexture* DX12SwapChain::GetBackBuffer(u8 backBufferIndex)
 {
     return backBuffers[backBufferIndex].get();

--- a/src/DX12/DX12SwapChain.h
+++ b/src/DX12/DX12SwapChain.h
@@ -28,6 +28,7 @@ public:
     virtual void Resize(u32 width, u32 height) override;
 
     virtual void SetVSync(bool enableVSync) override;
+    virtual bool NeedsFlushForVSyncToggle() override;
 
     virtual RHITexture* GetBackBuffer(u8 backBufferIndex) override;
 

--- a/src/DX12/DX12SwapChain.h
+++ b/src/DX12/DX12SwapChain.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <vector>
+
+#include <Vex/RHI/RHISwapChain.h>
+#include <Vex/UniqueHandle.h>
+
+#include <DX12/DX12Headers.h>
+
+namespace vex
+{
+struct PlatformWindow;
+class RHITexture;
+} // namespace vex
+
+namespace vex::dx12
+{
+
+class DX12SwapChain : public RHISwapChain
+{
+public:
+    DX12SwapChain(const ComPtr<DX12Device>& device,
+                  SwapChainDescription desc,
+                  const ComPtr<ID3D12CommandQueue>& commandQueue,
+                  const PlatformWindow& platformWindow);
+    virtual ~DX12SwapChain() override;
+    virtual void Present() override;
+    virtual void Resize(u32 width, u32 height) override;
+
+    virtual void SetVSync(bool enableVSync) override;
+
+    virtual RHITexture* GetBackBuffer(u8 backBufferIndex) override;
+
+private:
+    void ExtractBackBuffers();
+    static u8 GetBackBufferCount(FrameBuffering frameBuffering);
+
+    SwapChainDescription description;
+    ComPtr<IDXGISwapChain4> swapChain;
+    // Voluntarily does not have a custom deleter, backbuffers resize/destroy will happen after a flush.
+    std::vector<UniqueHandle<RHITexture>> backBuffers;
+};
+
+} // namespace vex::dx12

--- a/src/DX12/DX12Texture.cpp
+++ b/src/DX12/DX12Texture.cpp
@@ -1,0 +1,47 @@
+#include "DX12Texture.h"
+
+#include <Vex/Logger.h>
+
+#include <DX12/DX12Formats.h>
+
+namespace vex::dx12
+{
+
+DX12Texture::DX12Texture(std::string name, ComPtr<ID3D12Resource> nativeTex)
+    : texture(std::move(nativeTex))
+{
+    description.name = std::move(name);
+    D3D12_RESOURCE_DESC nativeDesc = texture->GetDesc();
+    if (nativeDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+    {
+        // Array size of 6 and TEXTURE2D resource dimension means we suppose the texture is a cubemap.
+        if (nativeDesc.DepthOrArraySize == 6)
+        {
+            description.type = TextureType::TextureCube;
+        }
+        else
+        {
+            description.type = TextureType::Texture2D;
+        }
+    }
+    else if (nativeDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D)
+    {
+        description.type = TextureType::Texture3D;
+    }
+    else
+    {
+        VEX_LOG(Fatal, "Vex DX12 RHI does not support 1D textures.");
+        return;
+    }
+    description.width = nativeDesc.Width;
+    description.height = nativeDesc.Height;
+    description.depthOrArraySize = static_cast<u32>(nativeDesc.DepthOrArraySize);
+    description.mips = nativeDesc.MipLevels;
+    description.format = DXGIToTextureFormat(nativeDesc.Format);
+}
+
+DX12Texture::~DX12Texture()
+{
+}
+
+} // namespace vex::dx12

--- a/src/DX12/DX12Texture.h
+++ b/src/DX12/DX12Texture.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Vex/RHI/RHITexture.h>
+
+#include <DX12/DX12Headers.h>
+
+namespace vex::dx12
+{
+
+class DX12Texture : public RHITexture
+{
+public:
+    DX12Texture(std::string name, ComPtr<ID3D12Resource> rawTex);
+    virtual ~DX12Texture() override;
+
+private:
+    ComPtr<ID3D12Resource> texture;
+};
+
+} // namespace vex::dx12

--- a/src/DX12/DXGIFactory.cpp
+++ b/src/DX12/DXGIFactory.cpp
@@ -49,4 +49,18 @@ std::string DXGIFactory::GetDeviceAdapterName(const ComPtr<ID3D12Device>& device
     return "Adapter Not Found";
 }
 
+ComPtr<IDXGISwapChain4> DXGIFactory::CreateSwapChain(const DXGI_SWAP_CHAIN_DESC1& desc,
+                                                     const ComPtr<ID3D12CommandQueue>& commandQueue,
+                                                     HWND hwnd)
+{
+    ComPtr<IDXGISwapChain4> swapChain;
+    chk << dxgiFactory->CreateSwapChainForHwnd(commandQueue.Get(),
+                                               hwnd,
+                                               &desc,
+                                               nullptr,
+                                               nullptr,
+                                               reinterpret_cast<IDXGISwapChain1**>(swapChain.GetAddressOf()));
+    return swapChain;
+}
+
 } // namespace vex::dx12

--- a/src/DX12/DXGIFactory.h
+++ b/src/DX12/DXGIFactory.h
@@ -14,6 +14,10 @@ public:
     static ComPtr<DX12Device> CreateDevice(IDXGIAdapter* adapter, D3D_FEATURE_LEVEL minimumFeatureLevel);
     static std::string GetDeviceAdapterName(const ComPtr<ID3D12Device>& device);
 
+    static ComPtr<IDXGISwapChain4> CreateSwapChain(const DXGI_SWAP_CHAIN_DESC1& desc,
+                                                   const ComPtr<ID3D12CommandQueue>& commandQueue,
+                                                   HWND hwnd);
+
     static ComPtr<IDXGIFactory7> dxgiFactory;
 };
 

--- a/src/Vex/Buffer.h
+++ b/src/Vex/Buffer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <limits>
+#include <string>
+
+#include <Vex/Types.h>
+
+namespace vex
+{
+
+struct BufferDescription
+{
+    std::string name;
+    u32 size;
+};
+
+// Strongly defined type represents a buffer.
+// We use a struct (instead of a typedef/using) to enforce compile-time correctness of handles.
+struct BufferHandle
+{
+    u32 value = std::numeric_limits<u32>::max();
+};
+
+static constexpr BufferHandle GInvalidBufferHandle;
+
+} // namespace vex

--- a/src/Vex/CommandQueueType.h
+++ b/src/Vex/CommandQueueType.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Vex/Types.h>
+
+namespace vex
+{
+
+namespace CommandQueueTypes
+{
+enum Value : u8
+{
+    // Transfer-only operations
+    Copy = 0,
+    // Compute operations (includes Copy capabilites)
+    Compute = 1,
+    // Graphics operations (includes Compute and Copy capabilities)
+    Graphics = 2,
+};
+// Not using a Count enum value allows us to more easily iterate over the CommandQueueTypes with magic_enum.
+static constexpr u8 Count = 3;
+} // namespace CommandQueueTypes
+
+using CommandQueueType = CommandQueueTypes::Value;
+
+} // namespace vex

--- a/src/Vex/Formats.cpp
+++ b/src/Vex/Formats.cpp
@@ -1,0 +1,25 @@
+#include "Formats.h"
+
+#include <utility>
+
+namespace vex
+{
+
+bool IsFormatSRGB(TextureFormat format)
+{
+    switch (format)
+    {
+    case TextureFormat::BC1_UNORM_SRGB:
+    case TextureFormat::BC2_UNORM_SRGB:
+    case TextureFormat::BC3_UNORM_SRGB:
+    case TextureFormat::BC7_UNORM_SRGB:
+    case TextureFormat::BGRA8_UNORM_SRGB:
+    case TextureFormat::RGBA8_UNORM_SRGB:
+        return true;
+    default:
+        return false;
+    }
+    std::unreachable();
+}
+
+} // namespace vex

--- a/src/Vex/Formats.h
+++ b/src/Vex/Formats.h
@@ -80,4 +80,6 @@ enum class TextureFormat : u8
     UNKNOWN,
 };
 
+bool IsFormatSRGB(TextureFormat format);
+
 } // namespace vex

--- a/src/Vex/FrameResource.h
+++ b/src/Vex/FrameResource.h
@@ -11,7 +11,7 @@ namespace vex
 
 // Determines how many frames should be in flight at once.
 // More frames in flight means less GPU starvation, but also more input latency.
-enum class FrameBuffering
+enum class FrameBuffering : u8
 {
     // One frame in flight at once
     Single = 1,

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -168,7 +168,10 @@ void GfxBackend::FlushGPU()
 
 void GfxBackend::SetVSync(bool useVSync)
 {
-    FlushGPU();
+    if (swapChain->NeedsFlushForVSyncToggle())
+    {
+        FlushGPU();
+    }
     swapChain->SetVSync(useVSync);
 }
 

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -6,15 +6,17 @@
 
 #include <Vex/FeatureChecker.h>
 #include <Vex/Logger.h>
+#include <Vex/PhysicalDevice.h>
 #include <Vex/RHI/RHI.h>
 #include <Vex/RHI/RHICommandList.h>
 #include <Vex/RHI/RHICommandPool.h>
 #include <Vex/RHI/RHIFence.h>
+#include <Vex/RHI/RHISwapChain.h>
 
 namespace vex
 {
 
-GfxBackend::GfxBackend(UniqueHandle<RenderHardwareInterface>&& newRHI, const BackendDescription& description)
+GfxBackend::GfxBackend(UniqueHandle<RHI>&& newRHI, const BackendDescription& description)
     : rhi(std::move(newRHI))
     , description(description)
     , commandPools(description.frameBuffering)
@@ -64,6 +66,11 @@ GfxBackend::GfxBackend(UniqueHandle<RenderHardwareInterface>&& newRHI, const Bac
     {
         commandPools.Get(std::to_underlying(frameIndex) - 1) = rhi->CreateCommandPool();
     }
+
+    swapChain = rhi->CreateSwapChain({ .format = description.swapChainFormat,
+                                       .frameBuffering = description.frameBuffering,
+                                       .useVSync = description.useVSync },
+                                     description.platformWindow);
 }
 
 GfxBackend::~GfxBackend()
@@ -114,7 +121,7 @@ void GfxBackend::StartFrame()
 
 void GfxBackend::EndFrame()
 {
-    // TODO: present the swapchain here
+    swapChain->Present();
 
     // Signal all queue fences.
     for (auto queueType : magic_enum::enum_values<CommandQueueType>())
@@ -157,6 +164,12 @@ void GfxBackend::FlushGPU()
     // The GPU should now be in an idle state.
     // Increment
     currentFrameIndex = nextFrameIndex;
+}
+
+void GfxBackend::SetVSync(bool useVSync)
+{
+    FlushGPU();
+    swapChain->SetVSync(useVSync);
 }
 
 } // namespace vex

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -2,22 +2,21 @@
 
 #include <array>
 
+#include <Vex/CommandQueueType.h>
 #include <Vex/Formats.h>
 #include <Vex/FrameResource.h>
-#include <Vex/PhysicalDevice.h>
 #include <Vex/PlatformWindow.h>
-#include <Vex/RHI/RHI.h>
+#include <Vex/RHI/RHIFwd.h>
 #include <Vex/UniqueHandle.h>
 
 namespace vex
 {
 
-class RHIFence;
-
 struct BackendDescription
 {
     PlatformWindow platformWindow;
     TextureFormat swapChainFormat;
+    bool useVSync = false;
     FrameBuffering frameBuffering = FrameBuffering::Triple;
     bool enableGPUDebugLayer = true;
     bool enableGPUBasedValidation = true;
@@ -26,7 +25,7 @@ struct BackendDescription
 class GfxBackend
 {
 public:
-    GfxBackend(UniqueHandle<RenderHardwareInterface>&& newRHI, const BackendDescription& description);
+    GfxBackend(UniqueHandle<RHI>&& newRHI, const BackendDescription& description);
     ~GfxBackend();
 
     void StartFrame();
@@ -35,6 +34,8 @@ public:
     // Flushes all current GPU commands.
     void FlushGPU();
 
+    void SetVSync(bool useVSync);
+
 private:
     // Index of the current frame, possible values depends on buffering:
     //  {0} if single buffering
@@ -42,7 +43,7 @@ private:
     //  {0, 1, 2} if triple buffering
     u8 currentFrameIndex = 0;
 
-    UniqueHandle<RenderHardwareInterface> rhi;
+    UniqueHandle<RHI> rhi;
 
     BackendDescription description;
 
@@ -54,6 +55,8 @@ private:
     std::array<UniqueHandle<RHIFence>, CommandQueueTypes::Count> queueFrameFences;
 
     FrameResource<UniqueHandle<RHICommandPool>> commandPools;
+
+    UniqueHandle<RHISwapChain> swapChain;
 };
 
 } // namespace vex

--- a/src/Vex/RHI/RHI.h
+++ b/src/Vex/RHI/RHI.h
@@ -2,41 +2,29 @@
 
 #include <vector>
 
-#include <Vex/EnumFlags.h>
-#include <Vex/PhysicalDevice.h>
+#include <Vex/CommandQueueType.h>
+#include <Vex/Types.h>
+#include <Vex/UniqueHandle.h>
 
 namespace vex
 {
 
+struct PhysicalDevice;
 class RHICommandPool;
 class RHICommandList;
 class RHIFence;
-
-namespace CommandQueueTypes
-{
-
-enum Value : u8
-{
-    // Transfer-only operations
-    Copy = 0,
-    // Compute operations (includes Copy capabilites)
-    Compute = 1,
-    // Graphics operations (includes Compute and Copy capabilities)
-    Graphics = 2,
-};
-
-// Not using a Count enum value allows us to more easily iterate over the CommandQueueTypes with magic_enum.
-static constexpr u8 Count = 3;
-
-} // namespace CommandQueueTypes
-
-using CommandQueueType = CommandQueueTypes::Value;
+class RHISwapChain;
+struct SwapChainDescription;
+struct PlatformWindow;
 
 struct RenderHardwareInterface
 {
     virtual ~RenderHardwareInterface() = default;
     virtual std::vector<UniqueHandle<PhysicalDevice>> EnumeratePhysicalDevices() = 0;
     virtual void Init(const UniqueHandle<PhysicalDevice>& physicalDevice) = 0;
+
+    virtual UniqueHandle<RHISwapChain> CreateSwapChain(const SwapChainDescription& description,
+                                                       const PlatformWindow& platformWindow) = 0;
 
     virtual UniqueHandle<RHICommandPool> CreateCommandPool() = 0;
 

--- a/src/Vex/RHI/RHIBuffer.h
+++ b/src/Vex/RHI/RHIBuffer.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace vex
+{
+
+class RHIBuffer
+{
+public:
+    ~RHIBuffer() = default;
+};
+
+} // namespace vex

--- a/src/Vex/RHI/RHIFwd.h
+++ b/src/Vex/RHI/RHIFwd.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace vex
+{
+
+struct RenderHardwareInterface;
+using RHI = RenderHardwareInterface;
+class RHIBuffer;
+class RHICommandList;
+class RHICommandPool;
+class RHIFence;
+class RHISwapChain;
+class RHITexture;
+
+} // namespace vex

--- a/src/Vex/RHI/RHISwapChain.h
+++ b/src/Vex/RHI/RHISwapChain.h
@@ -26,6 +26,7 @@ public:
 
     // Could lead to recreating the swapchain (eg: for Vulkan).
     virtual void SetVSync(bool enableVSync) = 0;
+    virtual bool NeedsFlushForVSyncToggle() = 0;
 
     virtual RHITexture* GetBackBuffer(u8 backBufferIndex) = 0;
 };

--- a/src/Vex/RHI/RHISwapChain.h
+++ b/src/Vex/RHI/RHISwapChain.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Vex/Formats.h>
+#include <Vex/FrameResource.h>
+#include <Vex/Types.h>
+#include <Vex/UniqueHandle.h>
+
+namespace vex
+{
+
+class RHITexture;
+
+struct SwapChainDescription
+{
+    TextureFormat format;
+    FrameBuffering frameBuffering;
+    bool useVSync = false;
+};
+
+class RHISwapChain
+{
+public:
+    virtual ~RHISwapChain() = default;
+    virtual void Present() = 0;
+    virtual void Resize(u32 width, u32 height) = 0;
+
+    // Could lead to recreating the swapchain (eg: for Vulkan).
+    virtual void SetVSync(bool enableVSync) = 0;
+
+    virtual RHITexture* GetBackBuffer(u8 backBufferIndex) = 0;
+};
+
+} // namespace vex

--- a/src/Vex/RHI/RHITexture.h
+++ b/src/Vex/RHI/RHITexture.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Vex/Texture.h>
+
+namespace vex
+{
+
+class RHITexture
+{
+public:
+    virtual ~RHITexture() = default;
+
+protected:
+    TextureDescription description;
+};
+
+} // namespace vex

--- a/src/Vex/Texture.h
+++ b/src/Vex/Texture.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <limits>
+#include <string>
+
+#include <Vex/Formats.h>
+#include <Vex/Types.h>
+
+namespace vex
+{
+
+enum class TextureType
+{
+    Texture2D,
+    TextureCube,
+    Texture3D,
+};
+
+struct TextureDescription
+{
+    std::string name;
+    TextureType type;
+    u32 width, height, depthOrArraySize;
+    u16 mips;
+    TextureFormat format;
+};
+
+// Strongly defined type represents a texture.
+// We use a struct (instead of a typedef/using) to enforce compile-time correctness of handles.
+struct TextureHandle
+{
+    u32 value = std::numeric_limits<u32>::max();
+};
+
+static constexpr TextureHandle GInvalidTextureHandle;
+
+} // namespace vex

--- a/src/Vulkan/VkRHI.cpp
+++ b/src/Vulkan/VkRHI.cpp
@@ -229,6 +229,12 @@ void VkRHI::Init(const UniqueHandle<PhysicalDevice>& vexPhysicalDevice)
     }
 }
 
+UniqueHandle<RHISwapChain> VkRHI::CreateSwapChain(const SwapChainDescription& description,
+                                                  const PlatformWindow& platformWindow)
+{
+    return nullptr;
+}
+
 UniqueHandle<RHICommandPool> VkRHI::CreateCommandPool()
 {
     return MakeUnique<VkCommandPool>(*device, commandQueues);

--- a/src/Vulkan/VkRHI.cpp
+++ b/src/Vulkan/VkRHI.cpp
@@ -16,8 +16,7 @@
 #include "VkExtensions.h"
 #include "VkHeaders.h"
 #include "VkPhysicalDevice.h"
-#include <Vex/Logger.h>
-#include <Vex/PlatformWindow.h>
+#include "VkSwapChain.h"
 
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
@@ -232,7 +231,7 @@ void VkRHI::Init(const UniqueHandle<PhysicalDevice>& vexPhysicalDevice)
 UniqueHandle<RHISwapChain> VkRHI::CreateSwapChain(const SwapChainDescription& description,
                                                   const PlatformWindow& platformWindow)
 {
-    return nullptr;
+    return MakeUnique<VkSwapChain>();
 }
 
 UniqueHandle<RHICommandPool> VkRHI::CreateCommandPool()

--- a/src/Vulkan/VkRHI.h
+++ b/src/Vulkan/VkRHI.h
@@ -22,6 +22,9 @@ public:
     virtual std::vector<UniqueHandle<PhysicalDevice>> EnumeratePhysicalDevices() override;
     virtual void Init(const UniqueHandle<PhysicalDevice>& physicalDevice) override;
 
+    virtual UniqueHandle<RHISwapChain> CreateSwapChain(const SwapChainDescription& description,
+                                                       const PlatformWindow& platformWindow) override;
+
     virtual UniqueHandle<RHICommandPool> CreateCommandPool() override;
 
     virtual void ExecuteCommandList(RHICommandList& commandList) override;

--- a/src/Vulkan/VkSwapChain.cpp
+++ b/src/Vulkan/VkSwapChain.cpp
@@ -15,6 +15,11 @@ void VkSwapChain::SetVSync(bool enableVSync)
 {
 }
 
+bool VkSwapChain::NeedsFlushForVSyncToggle()
+{
+    return true;
+}
+
 RHITexture* VkSwapChain::GetBackBuffer(u8 backBufferIndex)
 {
     return nullptr;

--- a/src/Vulkan/VkSwapChain.cpp
+++ b/src/Vulkan/VkSwapChain.cpp
@@ -1,0 +1,23 @@
+#include "VkSwapChain.h"
+
+namespace vex::vk
+{
+
+void VkSwapChain::Present()
+{
+}
+
+void VkSwapChain::Resize(u32 width, u32 height)
+{
+}
+
+void VkSwapChain::SetVSync(bool enableVSync)
+{
+}
+
+RHITexture* VkSwapChain::GetBackBuffer(u8 backBufferIndex)
+{
+    return nullptr;
+}
+
+} // namespace vex::vk

--- a/src/Vulkan/VkSwapChain.h
+++ b/src/Vulkan/VkSwapChain.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Vex/RHI/RHISwapChain.h>
+
+namespace vex::vk
+{
+
+class VkSwapChain : public RHISwapChain
+{
+public:
+    virtual void Present() override;
+    virtual void Resize(u32 width, u32 height) override;
+
+    virtual void SetVSync(bool enableVSync) override;
+
+    virtual RHITexture* GetBackBuffer(u8 backBufferIndex) override;
+};
+
+} // namespace vex::vk

--- a/src/Vulkan/VkSwapChain.h
+++ b/src/Vulkan/VkSwapChain.h
@@ -12,6 +12,7 @@ public:
     virtual void Resize(u32 width, u32 height) override;
 
     virtual void SetVSync(bool enableVSync) override;
+    virtual bool NeedsFlushForVSyncToggle() override;
 
     virtual RHITexture* GetBackBuffer(u8 backBufferIndex) override;
 };


### PR DESCRIPTION
- Refactor of vex RHI types (just a cleanup)
- Increased vex/ usage of forward declaration to cleanup files and improve compile times
- Added dx12 swapchain with vsync toggle. Currently vsync toggle could cause a GPU flush (function on the swap chain gives this info to the backend, which could potentially be improved).