### PR TITLE
feat: added dx12-only and vk-only windows CI steps

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -178,7 +178,7 @@ jobs:
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        ${{ matrix.os != 'windows-latest' && format('-DCMAKE_BUILD_TYPE={0}', matrix.build_type) || '' }}
         -DVEX_BUILD_EXAMPLES=ON
         ${{ matrix.graphics_api == 'directx12' && '-DVEX_ENABLE_VULKAN=OFF -DVEX_ENABLE_DX12=ON' || '' }}
         ${{ matrix.graphics_api == 'vulkan' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DX12=OFF' || '' }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -113,9 +113,7 @@ jobs:
         sudo apt-get update
         
         # Install Clang 19 and associated libraries
-        sudo apt-get install -y clang-19 \
-          libc++-19-dev \
-          libc++abi-19-dev
+        sudo apt-get install -y clang-19
         
         # Set Clang 19 as the default
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
@@ -179,7 +177,6 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DVEX_BUILD_EXAMPLES=ON
-        ${{ matrix.os == 'ubuntu-latest' && matrix.c_compiler == 'clang' && '-DCMAKE_CXX_FLAGS="-stdlib=libc++ -std=c++23"' || '' }}
         ${{ matrix.graphics_api == 'directx' && '-DVEX_ENABLE_VULKAN=OFF -DVEX_ENABLE_DIRECTX=ON' || '' }}
         ${{ matrix.graphics_api == 'vulkan' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DIRECTX=OFF' || '' }}
         ${{ matrix.graphics_api == 'vulkan_directx' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DIRECTX=ON' || '' }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -73,8 +73,9 @@ jobs:
         submodules: recursive
 
     # GitHub Action's ubuntu image has a GCC which does not support <print> (added in GCC 13).
+    # We need the latest version of GCC for both compilation with GCC and Clang since we use libstdc++.
     - name: Install latest GCC
-      if: matrix.os == 'ubuntu-latest' && matrix.c_compiler == 'gcc'
+      if: matrix.os == 'ubuntu-latest'
       run: |
         # Add the ubuntu-toolchain-r/test PPA which provides newer GCC versions
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -52,6 +52,18 @@ jobs:
           # Remove Vulkan+DirectX configurations from Linux (DirectX not available)
           - os: ubuntu-latest
             graphics_api: vulkan_directx
+          # Reduce the number of different jobs by limiting the directx-only / vulkan only builds to release targets
+          - build_type: Debug
+            graphics_api: directx
+          - build_type: Debug
+            graphics_api: vulkan
+          - os: windows-latest
+            c_compiler: clang
+            graphics_api: directx
+          - os: windows-latest
+            c_compiler: clang
+            graphics_api: vulkan
+
 
     name: ${{ matrix.os }} ${{ matrix.c_compiler }} ${{ matrix.build_type }} ${{ matrix.graphics_api }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         build_type: [Debug, Release]
         c_compiler: [gcc, clang, cl]
-        graphics_api: [vulkan, directx, vulkan_directx]
+        graphics_api: [vulkan, directx12, vulkan_directx12]
         include:
           - os: windows-latest
             c_compiler: cl
@@ -48,18 +48,18 @@ jobs:
             c_compiler: cl
           # Remove DirectX-only configurations from Linux (not supported)
           - os: ubuntu-latest
-            graphics_api: directx
+            graphics_api: directx12
           # Remove Vulkan+DirectX configurations from Linux (DirectX not available)
           - os: ubuntu-latest
-            graphics_api: vulkan_directx
+            graphics_api: vulkan_directx12
           # Reduce the number of different jobs by limiting the directx-only / vulkan only builds to release targets
           - build_type: Debug
-            graphics_api: directx
+            graphics_api: directx12
           - build_type: Debug
             graphics_api: vulkan
           - os: windows-latest
             c_compiler: clang
-            graphics_api: directx
+            graphics_api: directx12
           - os: windows-latest
             c_compiler: clang
             graphics_api: vulkan
@@ -127,7 +127,7 @@ jobs:
         clang++ --version
 
     - name: Install Vulkan SDK (Windows)
-      if: matrix.os == 'windows-latest' && (matrix.graphics_api == 'vulkan' || matrix.graphics_api == 'vulkan_directx')
+      if: matrix.os == 'windows-latest' && (matrix.graphics_api == 'vulkan' || matrix.graphics_api == 'vulkan_directx12')
       uses: humbletim/setup-vulkan-sdk@523828e49cd4afabce369c39c7ee6543a2b7a735
       with:
         vulkan-query-version: latest
@@ -180,9 +180,9 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DVEX_BUILD_EXAMPLES=ON
-        ${{ matrix.graphics_api == 'directx' && '-DVEX_ENABLE_VULKAN=OFF -DVEX_ENABLE_DIRECTX=ON' || '' }}
-        ${{ matrix.graphics_api == 'vulkan' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DIRECTX=OFF' || '' }}
-        ${{ matrix.graphics_api == 'vulkan_directx' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DIRECTX=ON' || '' }}
+        ${{ matrix.graphics_api == 'directx12' && '-DVEX_ENABLE_VULKAN=OFF -DVEX_ENABLE_DX12=ON' || '' }}
+        ${{ matrix.graphics_api == 'vulkan' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DX12=OFF' || '' }}
+        ${{ matrix.graphics_api == 'vulkan_directx12' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DX12=ON' || '' }}
         -S ${{ github.workspace }}
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -119,7 +119,9 @@ jobs:
         # Set Clang 19 as the default
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
-        
+        sudo update-alternatives --set clang /usr/bin/clang-19
+        sudo update-alternatives --set clang++ /usr/bin/clang++-19
+
         # Verify the version
         clang --version
         clang++ --version

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,5 +1,3 @@
-# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
-# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
 name: Build Vex and Examples
 
 on:
@@ -28,6 +26,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         build_type: [Debug, Release]
         c_compiler: [gcc, clang, cl]
+        graphics_api: [vulkan, directx, vulkan_directx]
         include:
           - os: windows-latest
             c_compiler: cl
@@ -42,12 +41,19 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
+          # Remove unsupported compilers from windows/linux
           - os: windows-latest
             c_compiler: gcc
           - os: ubuntu-latest
             c_compiler: cl
+          # Remove DirectX-only configurations from Linux (not supported)
+          - os: ubuntu-latest
+            graphics_api: directx
+          # Remove Vulkan+DirectX configurations from Linux (DirectX not available)
+          - os: ubuntu-latest
+            graphics_api: vulkan_directx
 
-    name: ${{ matrix.os }} ${{ matrix.c_compiler }} ${{ matrix.build_type }}
+    name: ${{ matrix.os }} ${{ matrix.c_compiler }} ${{ matrix.build_type }} ${{ matrix.graphics_api }}
 
     steps:
     - uses: actions/checkout@v4
@@ -108,7 +114,7 @@ jobs:
         clang++ --version
 
     - name: Install Vulkan SDK (Windows)
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest' && (matrix.graphics_api == 'vulkan' || matrix.graphics_api == 'vulkan_directx')
       uses: humbletim/setup-vulkan-sdk@523828e49cd4afabce369c39c7ee6543a2b7a735
       with:
         vulkan-query-version: latest
@@ -162,6 +168,9 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DVEX_BUILD_EXAMPLES=ON
         ${{ matrix.os == 'ubuntu-latest' && matrix.c_compiler == 'clang' && '-DCMAKE_CXX_FLAGS="-stdlib=libc++ -std=c++23"' || '' }}
+        ${{ matrix.graphics_api == 'directx' && '-DVEX_ENABLE_VULKAN=OFF -DVEX_ENABLE_DIRECTX=ON' || '' }}
+        ${{ matrix.graphics_api == 'vulkan' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DIRECTX=OFF' || '' }}
+        ${{ matrix.graphics_api == 'vulkan_directx' && '-DVEX_ENABLE_VULKAN=ON -DVEX_ENABLE_DIRECTX=ON' || '' }}
         -S ${{ github.workspace }}
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ target_include_directories(Vex PUBLIC
 )
 
 # DX12 project files
-if (WIN32 AND VEX_ENABLE_DX12)
+if (VEX_ENABLE_DX12)
     set(VEX_DX12_SOURCES 
         "src/DX12/DX12Headers.h"
         "src/DX12/DX12Formats.h" 
@@ -221,7 +221,7 @@ if (WIN32 AND VEX_ENABLE_DX12)
 endif()
 
 # Vulkan project files
-if (VEX_ENABLE_VULKAN AND Vulkan_FOUND)
+if (VEX_ENABLE_VULKAN)
     set(VEX_VULKAN_SOURCES
         "src/Vulkan/VkFormats.h" 
         "src/Vulkan/VkFeatureChecker.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,15 @@ message(STATUS "Checking for available graphics APIs...")
 set(VEX_AVAILABLE_BACKENDS "")
 
 # Check for DirectX 12 (Windows only)
+option(VEX_ENABLE_DX12 "Enable DirectX 12 backend if available" ON)
 if(WIN32)
     add_compile_definitions(NOMINMAX)
-    option(VEX_ENABLE_DX12 "Enable DirectX 12 backend if available" ON)
-    if(VEX_ENABLE_DX12)
+    if (VEX_ENABLE_DX12)
         list(APPEND VEX_AVAILABLE_BACKENDS "DirectX12")
     endif()
+else()
+    message(STATUS "DirectX SDK not supported on platforms other than WIN32.")
+    set(VEX_ENABLE_DX12 OFF)
 endif()
 
 # Check for Vulkan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,16 @@ set(EFSW_BUILD_SAMPLES OFF CACHE BOOL "Disable efsw samples" FORCE)
 
 FetchContent_MakeAvailable(efsw)
 
-# Fetch Vulkan-Hpp dependency
-message(STATUS "Fetching VulkanHpp...")
-FetchContent_Declare(
-    VulkanHpp
-    GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Hpp.git
-    GIT_TAG        v1.4.309
-)
-FetchContent_MakeAvailable(VulkanHpp)
+if (VEX_ENABLE_VULKAN)
+    # Fetch Vulkan-Hpp dependency
+    message(STATUS "Fetching VulkanHpp...")
+    FetchContent_Declare(
+        VulkanHpp
+        GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Hpp.git
+        GIT_TAG        v1.4.309
+    )
+    FetchContent_MakeAvailable(VulkanHpp)
+endif()
 
 # Fetch magic_enum dependency
 message(STATUS "Fetching magic_enum...")
@@ -287,7 +289,7 @@ endfunction()
 add_header_only_dependency(Vex efsw "${efsw_SOURCE_DIR}" "include" "efsw")
 
 # Static linking to DirectX 12
-if(WIN32 AND VEX_ENABLE_DX12)
+if (VEX_ENABLE_DX12)
     message(STATUS "DX12 found!")
 
     # DirectX Agility SDK headers
@@ -302,7 +304,7 @@ else()
 endif()
 
 function(vex_setup_d3d12_agility_runtime TARGET)
-    if (WIN32 AND VEX_ENABLE_DX12)
+    if (VEX_ENABLE_DX12)
         set(VEX_D3D12_AGILITY_SOURCE_SDK_DIR "${VEX_ROOT_DIR}/external/d3d12-agility-sdk/bin")
 
         if(NOT EXISTS "${VEX_D3D12_AGILITY_SOURCE_SDK_DIR}/D3D12Core.dll")
@@ -338,7 +340,7 @@ function(vex_setup_d3d12_agility_runtime TARGET)
 endfunction()
 
 # Static linking to Vulkan
-if(VEX_ENABLE_VULKAN AND Vulkan_FOUND)
+if(VEX_ENABLE_VULKAN)
     message(STATUS "Vulkan found!")
     target_sources(Vex PRIVATE ${VEX_VULKAN_SOURCES})
     target_link_libraries(Vex PUBLIC Vulkan::Vulkan)


### PR DESCRIPTION
- Fixes a few issues/typos with the current CI script
- Adds support for compiling on windows w/ only Vulkan or only Directx12 (only in release on cl, since we don't want this to generate too many steps)
- Fixes an issue where Clang 18 was being used instead of Clang 19