### PR TITLE
D3D12 agility sdk and other various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,14 +110,34 @@ FetchContent_MakeAvailable(magic_enum)
 
 # Fetch DX12 Agility SDK
 if (WIN32 AND VEX_ENABLE_DX12)
-    message(STATUS "Fetching DX12 Agility SDK...")
-    set(DX_AGILITY_SDK_VERSION "615")
-    FetchContent_Declare(
-        DirectX-Headers
-        GIT_REPOSITORY https://github.com/microsoft/DirectX-Headers.git
-        GIT_TAG v1.${DX_AGILITY_SDK_VERSION}.0
-    )
-    FetchContent_MakeAvailable(DirectX-Headers)
+    set(DX_AGILITY_VERSION "616")
+    set(AGILITY_SDK_DIR "${CMAKE_BINARY_DIR}/DirectX-AgilitySDK")
+    set(AGILITY_SDK_NUPKG "${CMAKE_BINARY_DIR}/agility_sdk.nupkg")
+    
+    # Download the NuGet package if not already downloaded
+    if(NOT EXISTS "${AGILITY_SDK_DIR}/build")
+        message(STATUS "Downloading DX12 Agility SDK 1.${DX_AGILITY_VERSION}.0...")
+        
+        file(DOWNLOAD 
+            "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.${DX_AGILITY_VERSION}.0"
+            "${AGILITY_SDK_NUPKG}"
+        )
+        
+        # NuGet packages are ZIP files with different extension
+        file(ARCHIVE_EXTRACT 
+            INPUT "${AGILITY_SDK_NUPKG}"
+            DESTINATION "${AGILITY_SDK_DIR}"
+        )
+        
+        message(STATUS "DirectX Agility SDK extracted to: ${AGILITY_SDK_DIR}")
+        
+        # Clean up the downloaded package
+        file(REMOVE "${AGILITY_SDK_NUPKG}")
+    endif()
+    
+    # Set the variables for use in functions
+    set(DX_AGILITY_SDK_VERSION ${DX_AGILITY_VERSION} CACHE STRING "DirectX Agility SDK Version" FORCE)
+    set(DX_AGILITY_SDK_SOURCE_DIR "${AGILITY_SDK_DIR}/build/native" CACHE PATH "DirectX Agility SDK Source Directory" FORCE)
 endif()
 # =========================================
 
@@ -271,6 +291,38 @@ message(STATUS "Setting up Vex headers...")
 
 # Function to create and link header-only libraries
 function(add_header_only_dependency TARGET DEP_NAME SOURCE_DIR INCLUDE_PATH INSTALL_PATH)
+    if(NOT EXISTS "${SOURCE_DIR}")
+        message(STATUS WARNING " Source directory does not exist: ${SOURCE_DIR}")
+        return()
+    endif()
+
+    set(FULL_INCLUDE_PATH "${SOURCE_DIR}/${INCLUDE_PATH}")
+    
+    # Debug: Check if include path exists
+    if(NOT EXISTS "${FULL_INCLUDE_PATH}")
+        message(STATUS WARNING " Include path does not exist: ${FULL_INCLUDE_PATH}")
+        return()
+    endif()
+
+    # Find all header files
+    file(GLOB_RECURSE HEADER_FILES 
+        "${FULL_INCLUDE_PATH}/*.h"
+        "${FULL_INCLUDE_PATH}/*.hpp"
+        "${FULL_INCLUDE_PATH}/*.hxx"
+        "${FULL_INCLUDE_PATH}/*.inl"
+    )
+    
+    if(HEADER_FILES)
+        message(STATUS "Found header files:")
+        foreach(HEADER ${HEADER_FILES})
+            # Show relative path from the include directory
+            file(RELATIVE_PATH REL_PATH "${FULL_INCLUDE_PATH}" "${HEADER}")
+            message(STATUS "  - ${REL_PATH}")
+        endforeach()
+    else()
+        message(WARNING "No header files found in: ${FULL_INCLUDE_PATH}")
+    endif()
+
     # Create interface library for the headers
     add_library(${TARGET}_${DEP_NAME}_headers INTERFACE)
     
@@ -299,7 +351,7 @@ if (VEX_ENABLE_DX12)
     message(STATUS "DX12 found!")
 
     # DirectX Agility SDK headers
-    add_header_only_dependency(Vex DirectX-Headers "${DirectX-Headers_SOURCE_DIR}" "include" "directx")
+    add_header_only_dependency(Vex DirectXAgilitySDK "${DX_AGILITY_SDK_SOURCE_DIR}" "include" "directx")
 
     target_link_libraries(Vex PUBLIC d3d12.lib dxgi.lib dxguid.lib)
     target_sources(Vex PRIVATE ${VEX_DX12_SOURCES})
@@ -311,10 +363,10 @@ endif()
 
 function(vex_setup_d3d12_agility_runtime TARGET)
     if (VEX_ENABLE_DX12)
-        set(VEX_D3D12_AGILITY_SOURCE_SDK_DIR "${VEX_ROOT_DIR}/external/d3d12-agility-sdk/bin")
+        set(VEX_D3D12_AGILITY_SOURCE_SDK_DIR "${DX_AGILITY_SDK_SOURCE_DIR}/bin/x64")
 
         if(NOT EXISTS "${VEX_D3D12_AGILITY_SOURCE_SDK_DIR}/D3D12Core.dll")
-            message(ERROR "Missing D3D12Core.dll in Agility SDK directory: ${VEX_D3D12_AGILITY_SOURCE_SDK_DIR}.")
+            message(STATUS ERROR " Missing D3D12Core.dll in Agility SDK directory: ${VEX_D3D12_AGILITY_SOURCE_SDK_DIR}.")
             return()
         endif()
 
@@ -341,7 +393,7 @@ function(vex_setup_d3d12_agility_runtime TARGET)
             COMMENT "Copying Agility SDK's DLLs to output directory : $<TARGET_FILE_DIR:${TARGET}>/D3D12..."
         )
 
-        message(STATUS "D3D12 Agility SDK will be deployed with ${TARGET}")
+        message(STATUS "D3D12 Agility SDK 1.${DX_AGILITY_SDK_VERSION}.0 will be deployed with ${TARGET}")
     endif()
 endfunction()
 

--- a/src/DX12/DX12CommandList.cpp
+++ b/src/DX12/DX12CommandList.cpp
@@ -174,7 +174,7 @@ void DX12CommandList::SetLayoutLocalConstants(const RHIResourceLayout& layout,
     // Compute total size of constants (and make sure the constants fit in local constants).
     for (const auto& binding : constants)
     {
-        localConstantsByteSize += binding.size;
+        localConstantsByteSize += static_cast<u32>(binding.size);
     }
 
     if (localConstantsByteSize > dxResourceLayout.GetMaxLocalConstantSize())
@@ -293,9 +293,15 @@ void DX12CommandList::SetLayoutResources(const RHIResourceLayout& layout,
     switch (type)
     {
     case CommandQueueType::Graphics:
-        commandList->SetGraphicsRoot32BitConstants(0, bindlessHandles.size(), bindlessHandles.data(), 0);
+        commandList->SetGraphicsRoot32BitConstants(0,
+                                                   static_cast<u32>(bindlessHandles.size()),
+                                                   bindlessHandles.data(),
+                                                   0);
     case CommandQueueType::Compute:
-        commandList->SetComputeRoot32BitConstants(0, bindlessHandles.size(), bindlessHandles.data(), 0);
+        commandList->SetComputeRoot32BitConstants(0,
+                                                  static_cast<u32>(bindlessHandles.size()),
+                                                  bindlessHandles.data(),
+                                                  0);
     case CommandQueueType::Copy:
     default:
         break;

--- a/src/DX12/DX12Headers.h
+++ b/src/DX12/DX12Headers.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <directx/d3d12.h>
-#include <directx/d3dx12.h>
-#include <directx/dxgicommon.h>
-#include <directx/dxgiformat.h>
+#include <d3d12.h>
+#include <d3dx12/d3dx12.h>
 #include <dxgi1_6.h>
+#include <dxgicommon.h>
 #include <dxgidebug.h>
+#include <dxgiformat.h>
 #include <wrl/client.h>
 
 namespace vex::dx12

--- a/src/DX12/DX12ResourceLayout.cpp
+++ b/src/DX12/DX12ResourceLayout.cpp
@@ -35,8 +35,10 @@ u32 DX12ResourceLayout::GetMaxLocalConstantSize() const
     // Each global constant descriptor takes up 2 DWORDs in the root signature (as root descriptor).
     // There is the option of using a descriptor table for constants to reduce their size, but adding a level of
     // indirection, this is probably not needed thanks to bindless existing nowadays!
-    return std::max<u32>(0, (featureChecker.GetMaxRootSignatureDWORDSize() - 2 * globalConstants.size())) *
-           sizeof(DWORD);
+    return std::max<u32>(
+               0,
+               (featureChecker.GetMaxRootSignatureDWORDSize() - 2 * static_cast<u32>(globalConstants.size()))) *
+           static_cast<u32>(sizeof(DWORD));
 }
 
 ComPtr<ID3D12RootSignature>& DX12ResourceLayout::GetRootSignature()

--- a/src/DX12/DX12Texture.cpp
+++ b/src/DX12/DX12Texture.cpp
@@ -263,7 +263,7 @@ DX12Texture::DX12Texture(ComPtr<DX12Device>& device, std::string name, ComPtr<ID
         VEX_LOG(Fatal, "Vex DX12 RHI does not support 1D textures.");
         return;
     }
-    description.width = nativeDesc.Width;
+    description.width = static_cast<u32>(nativeDesc.Width);
     description.height = nativeDesc.Height;
     description.depthOrArraySize = static_cast<u32>(nativeDesc.DepthOrArraySize);
     description.mips = nativeDesc.MipLevels;

--- a/src/Vex/Containers/FreeList.h
+++ b/src/Vex/Containers/FreeList.h
@@ -14,13 +14,13 @@ namespace vex
 // Simple index allocator
 struct FreeListAllocator
 {
-    FreeListAllocator(size_t size = 0)
+    FreeListAllocator(u32 size = 0)
         : size{ size }
     {
         freeIndices.reserve(size);
-        for (i32 i = size - 1; i > 0; --i)
+        for (u32 i = 0; i < size; ++i)
         {
-            freeIndices.push_back(static_cast<u32>(i));
+            freeIndices.push_back(size - 1 - i);
         }
     }
 
@@ -37,14 +37,14 @@ struct FreeListAllocator
         std::ranges::sort(freeIndices, std::greater{});
     }
 
-    void Resize(size_t newSize)
+    void Resize(u32 newSize)
     {
         if (newSize == size)
         {
             return;
         }
 
-        size_t indicesPreviousSize = freeIndices.size();
+        u32 indicesPreviousSize = static_cast<u32>(freeIndices.size());
 
         // We only support resizing up!
         freeIndices.resize(indicesPreviousSize + newSize - size);
@@ -64,7 +64,7 @@ struct FreeListAllocator
         size = newSize;
     }
 
-    size_t size;
+    u32 size;
     std::vector<u32> freeIndices;
 };
 
@@ -75,7 +75,7 @@ template <class T, class HandleT>
 class FreeList
 {
 public:
-    FreeList(size_t size = 0)
+    FreeList(u32 size = 0)
         : values(size)
         , generations(size)
         , allocator(size)
@@ -103,7 +103,7 @@ public:
     {
         if (allocator.freeIndices.empty())
         {
-            Resize(values.size() * 2);
+            Resize(static_cast<u32>(values.size()) * 2);
         }
 
         u32 index = allocator.Allocate();
@@ -121,7 +121,7 @@ public:
     }
 
 private:
-    void Resize(size_t size)
+    void Resize(u32 size)
     {
         allocator.Resize(size);
         values.resize(size);

--- a/src/Vex/RHI/RHI.h
+++ b/src/Vex/RHI/RHI.h
@@ -15,8 +15,8 @@ namespace vex
 
 struct PhysicalDevice;
 struct ShaderKey;
-class GraphicsPipelineStateKey;
-class ComputePipelineStateKey;
+struct GraphicsPipelineStateKey;
+struct ComputePipelineStateKey;
 struct SwapChainDescription;
 struct PlatformWindow;
 class FeatureChecker;

--- a/src/Vex/RHI/RHICommandList.h
+++ b/src/Vex/RHI/RHICommandList.h
@@ -11,8 +11,8 @@ namespace vex
 {
 struct ConstantBinding;
 struct ResourceBinding;
-struct RHITexture;
-struct RHIBuffer;
+class RHITexture;
+class RHIBuffer;
 struct RHITextureBinding;
 struct RHIBufferBinding;
 
@@ -37,9 +37,9 @@ public:
     virtual void SetLayoutLocalConstants(const RHIResourceLayout& layout,
                                          std::span<const ConstantBinding> constants) = 0;
     virtual void SetLayoutResources(const RHIResourceLayout& layout,
-                                           std::span<RHITextureBinding> textures,
-                                           std::span<RHIBufferBinding> buffers,
-                                           RHIDescriptorPool& descriptorPool) = 0;
+                                    std::span<RHITextureBinding> textures,
+                                    std::span<RHIBufferBinding> buffers,
+                                    RHIDescriptorPool& descriptorPool) = 0;
     virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool) = 0;
 
     virtual void Dispatch(const std::array<u32, 3>& groupCount) = 0;

--- a/src/Vulkan/VkCommandList.cpp
+++ b/src/Vulkan/VkCommandList.cpp
@@ -44,11 +44,15 @@ void VkCommandList::Close()
 
 void VkCommandList::SetViewport(float x, float y, float width, float height, float minDepth, float maxDepth)
 {
+    // Manipulation to match behavior of DX12 and other APIs (this allows for hlsl shader code to work the same across
+    // different apis).
+    // This consists of moving the (x=0, y=0) point from the bottom-left (vk convention) to the top-left (dx, metal and
+    // console convention).
     ::vk::Viewport viewport{
         .x = x,
-        .y = y,
+        .y = y + height,
         .width = width,
-        .height = height,
+        .height = -height,
         .minDepth = minDepth,
         .maxDepth = maxDepth,
     };
@@ -59,10 +63,9 @@ void VkCommandList::SetViewport(float x, float y, float width, float height, flo
 
 void VkCommandList::SetScissor(i32 x, i32 y, u32 width, u32 height)
 {
-    // Special behavior to match behavior of DX12 and other APIs
     ::vk::Rect2D scissor{
-        .offset = { .x = x, .y = y + static_cast<i32>(height) },
-        .extent = { .width = width, .height = -height },
+        .offset = { .x = x, .y = y },
+        .extent = { .width = width, .height = height },
     };
 
     VEX_ASSERT(commandBuffer, "CommandBuffer must exist to set scissor");


### PR DESCRIPTION
- Fixes the D3D12 Agility SDK cmake integration. Instead of using fetch content, I instead manually obtain the nuget package and unzip it. This allows us to obtain binaries directly via CMake, instead of having to do it by hand.
- Fixes to various missing static_casts in code.
- Fixed Vulkan viewport trick to get dx12, metal and other hlsl shaders working w/ vk.