### PR TITLE
Added a way for ResourceCleanup to correctly free a texture's allocated bindless handles

### DIFF
--- a/src/DX12/DX12Texture.cpp
+++ b/src/DX12/DX12Texture.cpp
@@ -4,6 +4,7 @@
 
 #include <Vex/Logger.h>
 #include <Vex/Platform/Windows/WString.h>
+#include <Vex/RHI/RHIDescriptorPool.h>
 
 #include <DX12/DX12Formats.h>
 #include <DX12/HRChecker.h>
@@ -291,6 +292,17 @@ DX12Texture::DX12Texture(ComPtr<DX12Device>& device, std::string name, ComPtr<ID
 
 DX12Texture::~DX12Texture()
 {
+}
+
+void DX12Texture::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
+{
+    for (auto& [heapSlot, bindlessHandle] : cache | std::views::values)
+    {
+        if (bindlessHandle != GInvalidBindlessHandle)
+        {
+            descriptorPool.FreeStaticDescriptor(bindlessHandle);
+        }
+    }
 }
 
 CD3DX12_CPU_DESCRIPTOR_HANDLE DX12Texture::GetOrCreateRTVDSVView(ComPtr<DX12Device>& device, DX12TextureView view)

--- a/src/DX12/DX12Texture.h
+++ b/src/DX12/DX12Texture.h
@@ -53,6 +53,7 @@ public:
     // Takes ownership of the passed in texture.
     DX12Texture(ComPtr<DX12Device>& device, std::string name, ComPtr<ID3D12Resource> rawTex);
     virtual ~DX12Texture() override;
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
     ID3D12Resource* GetRawTexture()
     {

--- a/src/Vex/Containers/ResourceCleanup.cpp
+++ b/src/Vex/Containers/ResourceCleanup.cpp
@@ -1,5 +1,6 @@
 #include "ResourceCleanup.h"
 
+#include <Vex/Debug.h>
 #include <Vex/RHI/RHIBuffer.h>
 #include <Vex/RHI/RHIPipelineState.h>
 #include <Vex/RHI/RHITexture.h>
@@ -22,11 +23,37 @@ void ResourceCleanup::CleanupResource(CleanupVariant resource, i8 lifespan)
     resourcesInFlight.emplace_back(std::move(resource), lifespan);
 }
 
-void ResourceCleanup::FlushResources(i8 flushCount)
+void ResourceCleanup::FlushResources(i8 flushCount, RHIDescriptorPool& descriptorPool)
 {
+    std::vector<CleanupVariant> resourcesToDestroy;
     for (auto& [resource, lifespan] : resourcesInFlight)
     {
         lifespan = std::max(lifespan - flushCount, 0);
+    }
+
+    for (auto& [resource, lifespan] : resourcesInFlight)
+    {
+        if (lifespan == 0)
+        {
+            std::visit(
+                [&descriptorPool](auto& val)
+                {
+                    using T = std::decay_t<decltype(val)>;
+                    if constexpr (std::is_same_v<UniqueHandle<RHITexture>, T>)
+                    {
+                        val->FreeBindlessHandles(descriptorPool);
+                    }
+                    else if constexpr (std::is_same_v<UniqueHandle<RHIBuffer>, T>)
+                    {
+                        VEX_NOT_YET_IMPLEMENTED();
+                    }
+                    else
+                    {
+                        // Nothing to do.
+                    }
+                },
+                resource);
+        }
     }
 
     std::erase_if(resourcesInFlight, [](const std::pair<CleanupVariant, i8>& val) { return val.second == 0; });

--- a/src/Vex/Containers/ResourceCleanup.h
+++ b/src/Vex/Containers/ResourceCleanup.h
@@ -21,7 +21,7 @@ public:
 
     void CleanupResource(CleanupVariant resource);
     void CleanupResource(CleanupVariant resource, i8 lifespan);
-    void FlushResources(i8 flushCount);
+    void FlushResources(i8 flushCount, RHIDescriptorPool& descriptorPool);
 
 private:
     i8 defaultLifespan;

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -124,7 +124,7 @@ void GfxBackend::EndFrame(bool isFullscreenMode)
     currentFrameIndex = nextFrameIndex;
 
     // Flush all resources that were queued up for deletion.
-    resourceCleanup.FlushResources(1);
+    resourceCleanup.FlushResources(1, *descriptorPool);
 
     // Release the memory occupied by the command lists that are done.
     GetCurrentCommandPool().ReclaimAllCommandListMemory();
@@ -165,7 +165,7 @@ Texture GfxBackend::CreateTexture(TextureDescription description, ResourceLifeti
                     .description = std::move(description) };
 }
 
-void GfxBackend::DestroyTexture(Texture texture)
+void GfxBackend::DestroyTexture(const Texture& texture)
 {
     resourceCleanup.CleanupResource(std::move(textureRegistry[texture.handle]));
     textureRegistry.FreeElement(texture.handle);
@@ -188,7 +188,7 @@ void GfxBackend::FlushGPU()
     }
 
     // Release all stale resource now that the GPU is done with them.
-    resourceCleanup.FlushResources(std::to_underlying(description.frameBuffering));
+    resourceCleanup.FlushResources(std::to_underlying(description.frameBuffering), *descriptorPool);
 
     // Release the memory occupied by the command lists that are done.
     commandPools.ForEach([](auto& el) { el->ReclaimAllCommandListMemory(); });

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -11,8 +11,8 @@
 #include <Vex/FrameResource.h>
 #include <Vex/PipelineStateCache.h>
 #include <Vex/PlatformWindow.h>
-#include <Vex/RHI/RHIFwd.h>
 #include <Vex/Resource.h>
+#include <Vex/RHI/RHIFwd.h>
 #include <Vex/Texture.h>
 #include <Vex/UniqueHandle.h>
 
@@ -50,7 +50,7 @@ public:
     Texture CreateTexture(TextureDescription description, ResourceLifetime lifetime);
     // Destroys a texture, the handle passed in must be the one obtained from calling CreateTexture earlier.
     // Once destroyed the handle passed in is invalid and should no longer be used.
-    void DestroyTexture(Texture texture);
+    void DestroyTexture(const Texture& texture);
 
     // Flushes all current GPU commands.
     void FlushGPU();

--- a/src/Vex/RHI/RHITexture.h
+++ b/src/Vex/RHI/RHITexture.h
@@ -23,10 +23,13 @@ END_VEX_ENUM_FLAGS();
 
 // clang-format on
 
+class RHIDescriptorPool;
+
 class RHITexture
 {
 public:
     virtual ~RHITexture() = default;
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) = 0;
 
     const TextureDescription& GetDescription() const
     {

--- a/src/Vulkan/VkTexture.cpp
+++ b/src/Vulkan/VkTexture.cpp
@@ -14,6 +14,11 @@ VkBackbufferTexture::VkBackbufferTexture(TextureDescription&& inDescription, ::v
     description = std::move(inDescription);
 }
 
+void VkBackbufferTexture::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
+{
+    VEX_NOT_YET_IMPLEMENTED();
+}
+
 VkTexture::VkTexture(const TextureDescription& inDescription, ::vk::UniqueImage rawImage)
     : image{ std::move(rawImage) }
 {
@@ -30,6 +35,11 @@ VkTexture::VkTexture(VkGPUContext& ctx, TextureDescription&& inDescription)
 {
     description = std::move(inDescription);
     CreateImage(ctx);
+}
+
+void VkTexture::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
+{
+    VEX_NOT_YET_IMPLEMENTED();
 }
 
 void VkTexture::CreateImage(VkGPUContext& ctx)

--- a/src/Vulkan/VkTexture.h
+++ b/src/Vulkan/VkTexture.h
@@ -12,6 +12,7 @@ class VkBackbufferTexture : public RHITexture
 {
 public:
     VkBackbufferTexture(TextureDescription&& description, ::vk::Image backbufferImage);
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
     ::vk::Image image;
 };
@@ -26,6 +27,7 @@ public:
     // Creates a new image
     // ...
     VkTexture(VkGPUContext& ctx, TextureDescription&& description);
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
 private:
     void CreateImage(VkGPUContext& ctx);


### PR DESCRIPTION
- For now done with a simple std::visit, could potentially look into doing something more robust (some sort of OnPreDestroy method that all types registered with the ResourceCleanup would have).