### PR TITLE
Graphics pipeline basic draw (+ new example)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,9 @@ add_library(Vex STATIC
     "src/Vex/ShaderResourceContext.h"
     "src/Vex/ShaderResourceContext.cpp"
     "src/Vex/ShaderGen.h"
- "src/Vex/GraphicsPipeline.h")
+    "src/Vex/GraphicsPipeline.h"
+    "src/Vex/DrawHelpers.h"
+)
 
 if (WIN32)
     target_sources(Vex PRIVATE
@@ -266,7 +268,9 @@ if (VEX_ENABLE_DX12)
         "src/DX12/DX12DescriptorPool.cpp"
         "src/DX12/DX12States.h"
         "src/DX12/DX12States.cpp"
-     "src/DX12/DX12GraphicsPipeline.h" "src/DX12/DX12GraphicsPipeline.cpp")
+        "src/DX12/DX12GraphicsPipeline.h"
+        "src/DX12/DX12GraphicsPipeline.cpp"
+    )
 endif()
 
 # Vulkan project files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,25 +77,6 @@ endif()
 # Dependencies fetching uses the FetchContent module
 include(FetchContent)
 
-# Fetch efsw dependency
-message(STATUS "Fetching efsw...")
-FetchContent_Declare(
-    efsw
-    GIT_REPOSITORY https://github.com/SpartanJ/efsw.git
-    GIT_TAG        1.4.1
-)
-# Completely override efsw's build options
-set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)  # Enable option() to override cached variables
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Force static libraries" FORCE)
-set(EFSW_SHARED OFF CACHE BOOL "Disable efsw shared library" FORCE)
-set(EFSW_STATIC ON CACHE BOOL "Enable efsw static library" FORCE)
-
-# Prevent any additional targets
-set(EFSW_BUILD_TEST OFF CACHE BOOL "Disable efsw tests" FORCE)
-set(EFSW_BUILD_SAMPLES OFF CACHE BOOL "Disable efsw samples" FORCE)
-
-FetchContent_MakeAvailable(efsw)
-
 if (VEX_ENABLE_VULKAN)
     # Fetch Vulkan-Hpp dependency
     message(STATUS "Fetching VulkanHpp...")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ add_library(Vex STATIC
     "src/Vex/ShaderResourceContext.h"
     "src/Vex/ShaderResourceContext.cpp"
     "src/Vex/ShaderGen.h"
-)
+ "src/Vex/GraphicsPipeline.h")
 
 if (WIN32)
     target_sources(Vex PRIVATE
@@ -266,7 +266,7 @@ if (VEX_ENABLE_DX12)
         "src/DX12/DX12DescriptorPool.cpp"
         "src/DX12/DX12States.h"
         "src/DX12/DX12States.cpp"
-    )
+     "src/DX12/DX12GraphicsPipeline.h" "src/DX12/DX12GraphicsPipeline.cpp")
 endif()
 
 # Vulkan project files

--- a/examples/example_hello_triangle/HelloTriangleApplication.cpp
+++ b/examples/example_hello_triangle/HelloTriangleApplication.cpp
@@ -34,16 +34,16 @@ HelloTriangleApplication::HelloTriangleApplication()
             .enableGPUDebugLayer = !VEX_SHIPPING,
             .enableGPUBasedValidation = !VEX_SHIPPING });
 
-    workingTexture = graphics->CreateTexture({ .name = "Working Texture",
-                                               .type = vex::TextureType::Texture2D,
-                                               .width = DefaultWidth,
-                                               .height = DefaultHeight,
-                                               .depthOrArraySize = 1,
-                                               .mips = 1,
-                                               .format = vex::TextureFormat::RGBA8_UNORM,
-                                               .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess,
-                                               .clearValue{ .enabled = false } },
-                                             vex::ResourceLifetime::Static);
+    workingTexture =
+        graphics->CreateTexture({ .name = "Working Texture",
+                                  .type = vex::TextureType::Texture2D,
+                                  .width = DefaultWidth,
+                                  .height = DefaultHeight,
+                                  .depthOrArraySize = 1,
+                                  .mips = 1,
+                                  .format = vex::TextureFormat::RGBA8_UNORM,
+                                  .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess },
+                                vex::ResourceLifetime::Static);
 
 #if defined(_WIN32)
     // Suggestion of an intrusive (à la Unreal) way to display errors.
@@ -141,14 +141,16 @@ void HelloTriangleApplication::OnResize(GLFWwindow* window, uint32_t width, uint
 
     ExampleApplication::OnResize(window, width, height);
 
-    workingTexture = graphics->CreateTexture({ .name = "Working Texture",
-                                               .type = vex::TextureType::Texture2D,
-                                               .width = width,
-                                               .height = height,
-                                               .depthOrArraySize = 1,
-                                               .mips = 1,
-                                               .format = vex::TextureFormat::RGBA8_UNORM,
-                                               .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess,
-                                               .clearValue{ .enabled = false } },
-                                             vex::ResourceLifetime::Static);
+    workingTexture = graphics->CreateTexture(
+        {
+            .name = "Working Texture",
+            .type = vex::TextureType::Texture2D,
+            .width = width,
+            .height = height,
+            .depthOrArraySize = 1,
+            .mips = 1,
+            .format = vex::TextureFormat::RGBA8_UNORM,
+            .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess,
+        },
+        vex::ResourceLifetime::Static);
 }

--- a/examples/example_hello_triangle/HelloTriangleApplication.cpp
+++ b/examples/example_hello_triangle/HelloTriangleApplication.cpp
@@ -9,6 +9,28 @@
 
 #include <GLFW/glfw3native.h>
 
+#if defined(__linux__)
+// Undefine problematic X11 macros
+#ifdef Always
+#undef Always
+#endif
+#ifdef None
+#undef None
+#endif
+#ifdef Success
+#undef Success
+#endif
+#ifdef Bool
+#undef Bool
+#endif
+#ifdef True
+#undef True
+#endif
+#ifdef False
+#undef False
+#endif
+#endif
+
 #include <Vex/Logger.h>
 
 HelloTriangleApplication::HelloTriangleApplication()

--- a/examples/example_hello_triangle/main.cpp
+++ b/examples/example_hello_triangle/main.cpp
@@ -6,7 +6,6 @@
 
 int main()
 {
-    // TODO: make the world a triangle...
     HelloTriangleApplication application;
     application.Run();
 }

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
@@ -34,16 +34,16 @@ HelloTriangleGraphicsApplication::HelloTriangleGraphicsApplication()
             .enableGPUDebugLayer = !VEX_SHIPPING,
             .enableGPUBasedValidation = !VEX_SHIPPING });
 
-    workingTexture = graphics->CreateTexture({ .name = "Working Texture",
-                                               .type = vex::TextureType::Texture2D,
-                                               .width = DefaultWidth,
-                                               .height = DefaultHeight,
-                                               .depthOrArraySize = 1,
-                                               .mips = 1,
-                                               .format = vex::TextureFormat::RGBA8_UNORM,
-                                               .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess,
-                                               .clearValue{ .enabled = false } },
-                                             vex::ResourceLifetime::Static);
+    workingTexture =
+        graphics->CreateTexture({ .name = "Working Texture",
+                                  .type = vex::TextureType::Texture2D,
+                                  .width = DefaultWidth,
+                                  .height = DefaultHeight,
+                                  .depthOrArraySize = 1,
+                                  .mips = 1,
+                                  .format = vex::TextureFormat::RGBA8_UNORM,
+                                  .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess },
+                                vex::ResourceLifetime::Static);
 
 #if defined(_WIN32)
     // Suggestion of an intrusive (à la Unreal) way to display errors.
@@ -105,31 +105,51 @@ void HelloTriangleGraphicsApplication::Run()
 
         {
             auto ctx = graphics->BeginScopedCommandContext(vex::CommandQueueType::Graphics);
+
+            vex::DrawDescription drawDesc{
+                .vertexShader = { .path = std::filesystem::current_path()
+                                              .parent_path()
+                                              .parent_path()
+                                              .parent_path()
+                                              .parent_path() /
+                                          "examples" / "example_hello_triangle_graphics_pipeline" /
+                                          "HelloTriangleGraphicsShader.hlsl",
+                                  .entryPoint = "VSMain",
+                                  .type = vex::ShaderType::VertexShader },
+                .pixelShader = { .path = std::filesystem::current_path()
+                                             .parent_path()
+                                             .parent_path()
+                                             .parent_path()
+                                             .parent_path() /
+                                         "examples" / "example_hello_triangle_graphics_pipeline" /
+                                         "HelloTriangleGraphicsShader.hlsl",
+                                 .entryPoint = "PSMain",
+                                 .type = vex::ShaderType::PixelShader }
+            };
+
+            ctx.SetScissor(0, 0, DefaultWidth, DefaultHeight);
+
+            vex::TextureClearValue clearValue{ .flags = vex::TextureClear::ClearColor, .color = { 1, 0.5f, 1, 1 } };
+            ctx.ClearTexture(vex::ResourceBinding{ .name = "Backbuffer", .texture = graphics->GetCurrentBackBuffer() },
+                             &clearValue);
+
+            ctx.SetViewport(0, 0, DefaultWidth / 2.0f, DefaultHeight);
             ctx.Draw(
-                { .vertexShader = { .path = std::filesystem::current_path()
-                                                .parent_path()
-                                                .parent_path()
-                                                .parent_path()
-                                                .parent_path() /
-                                            "examples" / "example_hello_triangle_graphics_pipeline" /
-                                            "HelloTriangleGraphicsShader.hlsl",
-                                    .entryPoint = "VSMain",
-                                    .type = vex::ShaderType::VertexShader },
-                  .pixelShader = { .path = std::filesystem::current_path()
-                                               .parent_path()
-                                               .parent_path()
-                                               .parent_path()
-                                               .parent_path() /
-                                           "examples" / "example_hello_triangle_graphics_pipeline" /
-                                           "HelloTriangleGraphicsShader.hlsl",
-                                   .entryPoint = "PSMain",
-                                   .type = vex::ShaderType::PixelShader } },
+                drawDesc,
                 {},
                 {},
                 {},
                 { { vex::ResourceBinding{ .name = "OutputTexture", .texture = graphics->GetCurrentBackBuffer() } } },
                 3);
-            // ctx.Copy(workingTexture, graphics->GetCurrentBackBuffer());
+
+            ctx.SetViewport(DefaultWidth / 2.0f, 0, DefaultWidth / 2.0f, DefaultHeight);
+            ctx.Draw(
+                drawDesc,
+                {},
+                {},
+                {},
+                { { vex::ResourceBinding{ .name = "OutputTexture", .texture = graphics->GetCurrentBackBuffer() } } },
+                3);
         }
 
         graphics->EndFrame(windowMode == Fullscreen);
@@ -147,14 +167,14 @@ void HelloTriangleGraphicsApplication::OnResize(GLFWwindow* window, uint32_t wid
 
     ExampleApplication::OnResize(window, width, height);
 
-    workingTexture = graphics->CreateTexture({ .name = "Working Texture",
-                                               .type = vex::TextureType::Texture2D,
-                                               .width = width,
-                                               .height = height,
-                                               .depthOrArraySize = 1,
-                                               .mips = 1,
-                                               .format = vex::TextureFormat::RGBA8_UNORM,
-                                               .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess,
-                                               .clearValue{ .enabled = false } },
-                                             vex::ResourceLifetime::Static);
+    workingTexture =
+        graphics->CreateTexture({ .name = "Working Texture",
+                                  .type = vex::TextureType::Texture2D,
+                                  .width = width,
+                                  .height = height,
+                                  .depthOrArraySize = 1,
+                                  .mips = 1,
+                                  .format = vex::TextureFormat::RGBA8_UNORM,
+                                  .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess },
+                                vex::ResourceLifetime::Static);
 }

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
@@ -110,7 +110,7 @@ void HelloTriangleGraphicsApplication::Run()
         {
             auto ctx = graphics->BeginScopedCommandContext(vex::CommandQueueType::Graphics);
 
-            ctx.SetScissor(0, 0, DefaultWidth, DefaultHeight);
+            ctx.SetScissor(0, 0, width, height);
 
             // Clear backbuffer.
             vex::TextureClearValue clearValue{ .flags = vex::TextureClear::ClearColor, .color = { 1, 0.5f, 1, 1 } };
@@ -137,9 +137,9 @@ void HelloTriangleGraphicsApplication::Run()
                 .renderTargets = renderTargets,
             };
 
-            ctx.SetViewport(0, 0, DefaultWidth / 2.0f, DefaultHeight);
+            ctx.SetViewport(0, 0, width / 2.0f, height);
             ctx.Draw(drawDesc, drawResources, 3);
-            ctx.SetViewport(DefaultWidth / 2.0f, 0, DefaultWidth / 2.0f, DefaultHeight);
+            ctx.SetViewport(width / 2.0f, 0, width / 2.0f, height);
             ctx.Draw(drawDesc, drawResources, 3);
         }
 

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
@@ -1,0 +1,160 @@
+#include "HelloTriangleGraphicsApplication.h"
+
+#include <GLFW/glfw3.h>
+#if defined(_WIN32)
+#define GLFW_EXPOSE_NATIVE_WIN32
+#elif defined(__linux__)
+#define GLFW_EXPOSE_NATIVE_X11
+#endif
+
+#include <GLFW/glfw3native.h>
+
+#include <Vex/Logger.h>
+
+HelloTriangleGraphicsApplication::HelloTriangleGraphicsApplication()
+    : ExampleApplication("HelloTriangleGraphicsApplication")
+{
+#if defined(_WIN32)
+    vex::PlatformWindowHandle platformWindow = { .window = glfwGetWin32Window(window) };
+#elif defined(__linux__)
+    vex::PlatformWindowHandle platformWindow{ .window = glfwGetX11Window(window), .display = glfwGetX11Display() };
+#endif
+
+#define USE_VULKAN 0
+
+    graphics = CreateGraphicsBackend(
+#if VEX_VULKAN and USE_VULKAN
+        vex::GraphicsAPI::Vulkan,
+#else // VEX_DX12 and not FORCE_VULKAN
+        vex::GraphicsAPI::DirectX12,
+#endif
+        vex::BackendDescription{
+            .platformWindow = { .windowHandle = platformWindow, .width = DefaultWidth, .height = DefaultHeight },
+            .swapChainFormat = vex::TextureFormat::RGBA8_UNORM,
+            .enableGPUDebugLayer = !VEX_SHIPPING,
+            .enableGPUBasedValidation = !VEX_SHIPPING });
+
+    workingTexture = graphics->CreateTexture({ .name = "Working Texture",
+                                               .type = vex::TextureType::Texture2D,
+                                               .width = DefaultWidth,
+                                               .height = DefaultHeight,
+                                               .depthOrArraySize = 1,
+                                               .mips = 1,
+                                               .format = vex::TextureFormat::RGBA8_UNORM,
+                                               .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess,
+                                               .clearValue{ .enabled = false } },
+                                             vex::ResourceLifetime::Static);
+
+#if defined(_WIN32)
+    // Suggestion of an intrusive (à la Unreal) way to display errors.
+    // The handling of shader compilation errors is user choice.
+    graphics->SetShaderCompilationErrorsCallback(
+        [window = window](const std::vector<std::pair<vex::ShaderKey, std::string>>& errors) -> bool
+        {
+            if (!errors.empty())
+            {
+                std::string totalErrorMessage = "Error compiling shader(s):\n";
+                for (auto& [key, err] : errors)
+                {
+                    totalErrorMessage.append(std::format("Shader: {} - Error: {}\n", key, err));
+                }
+                totalErrorMessage.append("\nDo you want to retry?");
+
+                vex::i32 result = MessageBox(NULL,
+                                             totalErrorMessage.c_str(),
+                                             "Shader Compilation Error",
+                                             MB_ICONERROR | MB_YESNO | MB_DEFBUTTON2);
+                if (result == IDYES)
+                {
+                    return true;
+                }
+                else if (result == IDNO)
+                {
+                    VEX_LOG(vex::Error, "Unable to continue with shader errors. Closing application.");
+                    glfwSetWindowShouldClose(window, true);
+                }
+            }
+
+            return false;
+        });
+#endif
+}
+
+HelloTriangleGraphicsApplication::~HelloTriangleGraphicsApplication()
+{
+}
+
+void HelloTriangleGraphicsApplication::HandleKeyInput(int key, int scancode, int action, int mods)
+{
+    if (action == GLFW_PRESS)
+    {
+        if (key == GLFW_KEY_R)
+        {
+            graphics->RecompileChangedShaders();
+        }
+    }
+}
+
+void HelloTriangleGraphicsApplication::Run()
+{
+    while (!glfwWindowShouldClose(window))
+    {
+        glfwPollEvents();
+
+        graphics->StartFrame();
+
+        {
+            auto ctx = graphics->BeginScopedCommandContext(vex::CommandQueueType::Graphics);
+            ctx.Draw(
+                { .vertexShader = { .path = std::filesystem::current_path()
+                                                .parent_path()
+                                                .parent_path()
+                                                .parent_path()
+                                                .parent_path() /
+                                            "examples" / "example_hello_triangle_graphics_pipeline" /
+                                            "HelloTriangleGraphicsShader.hlsl",
+                                    .entryPoint = "VSMain",
+                                    .type = vex::ShaderType::VertexShader },
+                  .pixelShader = { .path = std::filesystem::current_path()
+                                               .parent_path()
+                                               .parent_path()
+                                               .parent_path()
+                                               .parent_path() /
+                                           "examples" / "example_hello_triangle_graphics_pipeline" /
+                                           "HelloTriangleGraphicsShader.hlsl",
+                                   .entryPoint = "PSMain",
+                                   .type = vex::ShaderType::PixelShader } },
+                {},
+                {},
+                {},
+                { { vex::ResourceBinding{ .name = "OutputTexture", .texture = graphics->GetCurrentBackBuffer() } } },
+                3);
+            // ctx.Copy(workingTexture, graphics->GetCurrentBackBuffer());
+        }
+
+        graphics->EndFrame(windowMode == Fullscreen);
+    }
+}
+
+void HelloTriangleGraphicsApplication::OnResize(GLFWwindow* window, uint32_t width, uint32_t height)
+{
+    if (width == 0 || height == 0)
+    {
+        return;
+    }
+
+    graphics->DestroyTexture(workingTexture);
+
+    ExampleApplication::OnResize(window, width, height);
+
+    workingTexture = graphics->CreateTexture({ .name = "Working Texture",
+                                               .type = vex::TextureType::Texture2D,
+                                               .width = width,
+                                               .height = height,
+                                               .depthOrArraySize = 1,
+                                               .mips = 1,
+                                               .format = vex::TextureFormat::RGBA8_UNORM,
+                                               .usage = vex::ResourceUsage::Read | vex::ResourceUsage::UnorderedAccess,
+                                               .clearValue{ .enabled = false } },
+                                             vex::ResourceLifetime::Static);
+}

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
@@ -9,6 +9,28 @@
 
 #include <GLFW/glfw3native.h>
 
+#if defined(__linux__)
+// Undefine problematic X11 macros
+#ifdef Always
+#undef Always
+#endif
+#ifdef None
+#undef None
+#endif
+#ifdef Success
+#undef Success
+#endif
+#ifdef Bool
+#undef Bool
+#endif
+#ifdef True
+#undef True
+#endif
+#ifdef False
+#undef False
+#endif
+#endif
+
 #include <Vex/Logger.h>
 
 HelloTriangleGraphicsApplication::HelloTriangleGraphicsApplication()

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.h
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Vex.h>
+
+#include "../ExampleApplication.h"
+
+class GLFWwindow;
+
+class HelloTriangleGraphicsApplication : public ExampleApplication
+{
+public:
+    HelloTriangleGraphicsApplication();
+    virtual ~HelloTriangleGraphicsApplication() override;
+    virtual void HandleKeyInput(int key, int scancode, int action, int mods) override;
+
+    void Run();
+
+protected:
+    virtual void OnResize(GLFWwindow* window, uint32_t width, uint32_t height) override;
+
+private:
+    vex::Texture workingTexture;
+};

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsShader.hlsl
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsShader.hlsl
@@ -4,13 +4,52 @@ void ComputeTriangleVertex(in uint vertexID, out float4 position, out float2 uv)
     position = float4(uv.x * 2 - 1, -uv.y * 2 + 1, 0, 1);
 }
 
-void VSMain(uint vertexID : SV_VertexID, out float4 pos : SV_POSITION)
+struct VSOutput
 {
-    float2 uv;
-    ComputeTriangleVertex(3 - vertexID, pos, uv);
+    float4 pos : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+VSOutput VSMain(in uint vertexID : SV_VertexID)
+{
+    VSOutput vs;
+    ComputeTriangleVertex(2 - vertexID, vs.pos, vs.uv);
+    return vs;
 }
 
-void PSMain(float4 position : SV_POSITION, out float4 outColor : SV_Target)
+// Simple function to check if a point is inside a triangle
+bool IsInsideTriangle(float2 p, float2 v0, float2 v1, float2 v2)
 {
-    outColor = float4(position.xyz, 1);
+    float2 e0 = v1 - v0;
+    float2 e1 = v2 - v1;
+    float2 e2 = v0 - v2;
+
+    float2 p0 = p - v0;
+    float2 p1 = p - v1;
+    float2 p2 = p - v2;
+
+    float c0 = p0.x * e0.y - p0.y * e0.x;
+    float c1 = p1.x * e1.y - p1.y * e1.x;
+    float c2 = p2.x * e2.y - p2.y * e2.x;
+
+    return (c0 >= 0 && c1 >= 0 && c2 >= 0) || (c0 <= 0 && c1 <= 0 && c2 <= 0);
+}
+
+float4 PSMain(VSOutput input)
+    : SV_Target
+{
+    // Define triangle vertices in normalized space
+    float2 v0 = float2(0.5, 0.1); // Bottom center
+    float2 v1 = float2(0.9, 0.8); // Top right
+    float2 v2 = float2(0.1, 0.8); // Top left
+
+    if (IsInsideTriangle(input.uv, v0, v1, v2))
+    {
+        float3 color = float3(input.uv.x, input.uv.y, 1 - input.uv.x * input.uv.y);
+        return float4(color, 1);
+    }
+    else
+    {
+        return float4(0, 0, 0, 1);
+    }
 }

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsShader.hlsl
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsShader.hlsl
@@ -1,0 +1,16 @@
+void ComputeTriangleVertex(in uint vertexID, out float4 position, out float2 uv)
+{
+    uv = float2((vertexID << 1) & 2, vertexID & 2);
+    position = float4(uv.x * 2 - 1, -uv.y * 2 + 1, 0, 1);
+}
+
+void VSMain(uint vertexID : SV_VertexID, out float4 pos : SV_POSITION)
+{
+    float2 uv;
+    ComputeTriangleVertex(3 - vertexID, pos, uv);
+}
+
+void PSMain(float4 position : SV_POSITION, out float4 outColor : SV_Target)
+{
+    outColor = float4(position.xyz, 1);
+}

--- a/examples/example_hello_triangle_graphics_pipeline/main.cpp
+++ b/examples/example_hello_triangle_graphics_pipeline/main.cpp
@@ -1,0 +1,11 @@
+#include <HelloTriangleGraphicsApplication.h>
+
+#include <iostream>
+
+#include <Vex.h>
+
+int main()
+{
+    HelloTriangleGraphicsApplication application;
+    application.Run();
+}

--- a/src/DX12/DX12CommandList.h
+++ b/src/DX12/DX12CommandList.h
@@ -36,6 +36,10 @@ public:
     virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout) override;
     virtual void SetInputAssembly(InputAssembly inputAssembly) override;
 
+    virtual void ClearTexture(RHITexture& rhiTexture,
+                              const ResourceBinding& clearBinding,
+                              const TextureClearValue& clearValue) override;
+
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) override;
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) override;
 

--- a/src/DX12/DX12CommandList.h
+++ b/src/DX12/DX12CommandList.h
@@ -34,9 +34,12 @@ public:
                                     std::span<RHIBufferBinding> buffers,
                                     RHIDescriptorPool& descriptorPool) override;
     virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout) override;
+    virtual void SetInputAssembly(InputAssembly inputAssembly) override;
 
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) override;
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) override;
+
+    virtual void Draw(u32 vertexCount) override;
 
     virtual void Dispatch(const std::array<u32, 3>& groupCount) override;
 

--- a/src/DX12/DX12GraphicsPipeline.cpp
+++ b/src/DX12/DX12GraphicsPipeline.cpp
@@ -1,0 +1,281 @@
+#include "DX12GraphicsPipeline.h"
+
+#include <DX12/DX12Formats.h>
+
+namespace vex::dx12
+{
+
+namespace GraphicsPipeline
+{
+
+D3D12_COMPARISON_FUNC GetD3D12ComparisonFuncFromCompareOp(CompareOp compareOp)
+{
+    if (compareOp == CompareOp::None)
+    {
+        return D3D12_COMPARISON_FUNC_NONE;
+    }
+    return static_cast<D3D12_COMPARISON_FUNC>(static_cast<int>(compareOp) + 1);
+}
+
+D3D12_STENCIL_OP GetD3D12StencilOpFromStencilOp(StencilOp stencilOp)
+{
+    return static_cast<D3D12_STENCIL_OP>(static_cast<int>(stencilOp) + 1);
+}
+
+D3D12_BLEND GetD3D12BlendFromBlendFactor(BlendFactor blendFactor)
+{
+    switch (blendFactor)
+    {
+    case BlendFactor::Zero:
+        return D3D12_BLEND_ZERO;
+    case BlendFactor::One:
+        return D3D12_BLEND_ONE;
+    case BlendFactor::SrcColor:
+        return D3D12_BLEND_SRC_COLOR;
+    case BlendFactor::OneMinusSrcColor:
+        return D3D12_BLEND_INV_SRC_COLOR;
+    case BlendFactor::DstColor:
+        return D3D12_BLEND_DEST_COLOR;
+    case BlendFactor::OneMinusDstColor:
+        return D3D12_BLEND_INV_DEST_COLOR;
+    case BlendFactor::SrcAlpha:
+        return D3D12_BLEND_SRC_ALPHA;
+    case BlendFactor::OneMinusSrcAlpha:
+        return D3D12_BLEND_INV_SRC_ALPHA;
+    case BlendFactor::DstAlpha:
+        return D3D12_BLEND_DEST_ALPHA;
+    case BlendFactor::OneMinusDstAlpha:
+        return D3D12_BLEND_INV_DEST_ALPHA;
+    case BlendFactor::ConstantColor:
+        return D3D12_BLEND_BLEND_FACTOR;
+    case BlendFactor::OneMinusConstantColor:
+        return D3D12_BLEND_INV_BLEND_FACTOR;
+    case BlendFactor::ConstantAlpha:
+        return D3D12_BLEND_BLEND_FACTOR; // DX12 doesn't separate color/alpha constants
+    case BlendFactor::OneMinusConstantAlpha:
+        return D3D12_BLEND_INV_BLEND_FACTOR;
+    case BlendFactor::SrcAlphaSaturate:
+        return D3D12_BLEND_SRC_ALPHA_SAT;
+    case BlendFactor::Src1Color:
+        return D3D12_BLEND_SRC1_COLOR;
+    case BlendFactor::OneMinusSrc1Color:
+        return D3D12_BLEND_INV_SRC1_COLOR;
+    case BlendFactor::Src1Alpha:
+        return D3D12_BLEND_SRC1_ALPHA;
+    case BlendFactor::OneMinusSrc1Alpha:
+        return D3D12_BLEND_INV_SRC1_ALPHA;
+    default:
+        return D3D12_BLEND_ZERO;
+    }
+}
+
+D3D12_BLEND_OP GetD3D12BlendOpFromBlendOp(BlendOp blendOp)
+{
+    return static_cast<D3D12_BLEND_OP>(static_cast<int>(blendOp) + 1);
+}
+
+CD3DX12_RASTERIZER_DESC GetDX12RasterizerStateFromRasterizerState(const RasterizerState& rasterizerState)
+{
+    CD3DX12_RASTERIZER_DESC desc(D3D12_DEFAULT);
+
+    // Convert fill mode
+    if (rasterizerState.polygonMode == PolygonMode::Line)
+    {
+        desc.FillMode = D3D12_FILL_MODE_WIREFRAME;
+    }
+    else
+    {
+        desc.FillMode = D3D12_FILL_MODE_SOLID;
+    }
+
+    // Convert cull mode
+    switch (rasterizerState.cullMode)
+    {
+    case CullMode::None:
+        desc.CullMode = D3D12_CULL_MODE_NONE;
+        break;
+    case CullMode::Front:
+        desc.CullMode = D3D12_CULL_MODE_FRONT;
+        break;
+    case CullMode::Back:
+        desc.CullMode = D3D12_CULL_MODE_BACK;
+        break;
+    }
+
+    // Convert winding order
+    desc.FrontCounterClockwise = (rasterizerState.winding == Winding::CounterClockwise);
+
+    // Depth bias
+    desc.DepthBias = static_cast<INT>(rasterizerState.depthBiasConstantFactor);
+    desc.DepthBiasClamp = rasterizerState.depthBiasClamp;
+    desc.SlopeScaledDepthBias = rasterizerState.depthBiasSlopeFactor;
+    desc.DepthClipEnable = !rasterizerState.depthClampEnabled; // Inverted logic
+
+    // Note: DX12 doesn't have direct equivalents for rasterizerDiscardEnabled and lineWidth, we ignore them.
+
+    return desc;
+}
+
+CD3DX12_BLEND_DESC GetDX12BlendStateFromColorBlendState(const ColorBlendState& blendState)
+{
+    CD3DX12_BLEND_DESC desc(D3D12_DEFAULT);
+
+    // DX12 doesn't support logic operations in the same way as Vulkan, we ignore them.
+
+    for (u32 i = 0; i < std::min<u32>(static_cast<u32>(blendState.attachments.size()), 8); ++i)
+    {
+        const auto& attachment = blendState.attachments[i];
+        auto& renderTarget = desc.RenderTarget[i];
+
+        renderTarget.BlendEnable = attachment.blendEnabled;
+        renderTarget.SrcBlend = GetD3D12BlendFromBlendFactor(attachment.srcColorBlendFactor);
+        renderTarget.DestBlend = GetD3D12BlendFromBlendFactor(attachment.dstColorBlendFactor);
+        renderTarget.BlendOp = GetD3D12BlendOpFromBlendOp(attachment.colorBlendOp);
+        renderTarget.SrcBlendAlpha = GetD3D12BlendFromBlendFactor(attachment.srcAlphaBlendFactor);
+        renderTarget.DestBlendAlpha = GetD3D12BlendFromBlendFactor(attachment.dstAlphaBlendFactor);
+        renderTarget.BlendOpAlpha = GetD3D12BlendOpFromBlendOp(attachment.alphaBlendOp);
+
+        // Convert color write mask
+        renderTarget.RenderTargetWriteMask = 0;
+        if (attachment.colorWriteMask & ColorWriteMask::Red)
+            renderTarget.RenderTargetWriteMask |= D3D12_COLOR_WRITE_ENABLE_RED;
+        if (attachment.colorWriteMask & ColorWriteMask::Green)
+            renderTarget.RenderTargetWriteMask |= D3D12_COLOR_WRITE_ENABLE_GREEN;
+        if (attachment.colorWriteMask & ColorWriteMask::Blue)
+            renderTarget.RenderTargetWriteMask |= D3D12_COLOR_WRITE_ENABLE_BLUE;
+        if (attachment.colorWriteMask & ColorWriteMask::Alpha)
+            renderTarget.RenderTargetWriteMask |= D3D12_COLOR_WRITE_ENABLE_ALPHA;
+    }
+
+    // Note: DX12 doesn't have blend constants in the same way, we set them when binding the PSO.
+
+    return desc;
+}
+
+D3D12_DEPTH_STENCIL_DESC GetDX12DepthStencilStateFromDepthStencilState(const DepthStencilState& depthStencilState)
+{
+    D3D12_DEPTH_STENCIL_DESC desc = {};
+
+    desc.DepthEnable = depthStencilState.depthTestEnabled;
+    desc.DepthWriteMask =
+        depthStencilState.depthWriteEnabled ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
+    desc.DepthFunc = GetD3D12ComparisonFuncFromCompareOp(depthStencilState.depthCompareOp);
+
+    // Stencil test
+    desc.StencilEnable = (depthStencilState.front.compareOp != CompareOp::Always ||
+                          depthStencilState.back.compareOp != CompareOp::Always);
+    desc.StencilReadMask = static_cast<UINT8>(depthStencilState.front.readMask);
+    desc.StencilWriteMask = static_cast<UINT8>(depthStencilState.front.writeMask);
+
+    // Front face stencil
+    desc.FrontFace.StencilFailOp = GetD3D12StencilOpFromStencilOp(depthStencilState.front.failOp);
+    desc.FrontFace.StencilDepthFailOp = GetD3D12StencilOpFromStencilOp(depthStencilState.front.depthFailOp);
+    desc.FrontFace.StencilPassOp = GetD3D12StencilOpFromStencilOp(depthStencilState.front.passOp);
+    desc.FrontFace.StencilFunc = GetD3D12ComparisonFuncFromCompareOp(depthStencilState.front.compareOp);
+
+    // Back face stencil
+    desc.BackFace.StencilFailOp = GetD3D12StencilOpFromStencilOp(depthStencilState.back.failOp);
+    desc.BackFace.StencilDepthFailOp = GetD3D12StencilOpFromStencilOp(depthStencilState.back.depthFailOp);
+    desc.BackFace.StencilPassOp = GetD3D12StencilOpFromStencilOp(depthStencilState.back.passOp);
+    desc.BackFace.StencilFunc = GetD3D12ComparisonFuncFromCompareOp(depthStencilState.back.compareOp);
+
+    // Note: DX12 doesn't support depth bounds testing or per-face stencil masks/references, we ignore them.
+
+    return desc;
+}
+
+std::vector<D3D12_INPUT_ELEMENT_DESC> GetDX12InputElementDescFromVertexInputAssembly(
+    const VertexInputLayout& vertexInputLayout)
+{
+    std::vector<D3D12_INPUT_ELEMENT_DESC> inputElements;
+    inputElements.reserve(vertexInputLayout.attributes.size());
+
+    for (const auto& attr : vertexInputLayout.attributes)
+    {
+        D3D12_INPUT_ELEMENT_DESC elementDesc = {};
+        elementDesc.SemanticName = attr.semanticName.c_str();
+        elementDesc.SemanticIndex = attr.semanticIndex;
+        elementDesc.Format = TextureFormatToDXGI(attr.format);
+        elementDesc.InputSlot = attr.binding;
+        elementDesc.AlignedByteOffset = attr.offset;
+
+        // Find the corresponding binding to determine input slot class
+        auto bindingIt = std::find_if(vertexInputLayout.bindings.begin(),
+                                      vertexInputLayout.bindings.end(),
+                                      [&](const VertexInputLayout::VertexBinding& binding)
+                                      { return binding.binding == attr.binding; });
+
+        if (bindingIt != vertexInputLayout.bindings.end())
+        {
+            elementDesc.InputSlotClass = (bindingIt->inputRate == VertexInputLayout::InputRate::PerInstance)
+                                             ? D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA
+                                             : D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
+            elementDesc.InstanceDataStepRate =
+                (bindingIt->inputRate == VertexInputLayout::InputRate::PerInstance) ? 1 : 0;
+        }
+        else
+        {
+            elementDesc.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
+            elementDesc.InstanceDataStepRate = 0;
+        }
+
+        inputElements.push_back(elementDesc);
+    }
+
+    return inputElements;
+}
+
+D3D12_PRIMITIVE_TOPOLOGY GetDX12PrimitiveTopologyFromInputAssembly(const InputAssembly& inputAssembly)
+{
+    switch (inputAssembly.topology)
+    {
+    case InputTopology::TriangleList:
+        return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+    case InputTopology::TriangleStrip:
+        return D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
+    case InputTopology::TriangleFan:
+        return D3D_PRIMITIVE_TOPOLOGY_TRIANGLEFAN;
+    default:
+        return D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+    }
+}
+
+D3D12_PRIMITIVE_TOPOLOGY_TYPE GetDX12PrimitiveTopologyTypeFromInputAssembly(const InputAssembly& inputAssembly)
+{
+    switch (inputAssembly.topology)
+    {
+    case InputTopology::TriangleList:
+    case InputTopology::TriangleStrip:
+    case InputTopology::TriangleFan:
+        return D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    default:
+        return D3D12_PRIMITIVE_TOPOLOGY_TYPE_UNDEFINED;
+    }
+}
+
+u32 GetNumRenderTargetsFromRenderTargetState(const RenderTargetState& renderTargetState)
+{
+    return static_cast<u32>(renderTargetState.colorFormats.size());
+}
+
+std::array<DXGI_FORMAT, 8> GetRTVFormatsFromRenderTargetState(const RenderTargetState& renderTargetState)
+{
+    std::array<DXGI_FORMAT, 8> result;
+
+    for (u32 i = 0; i < std::min<u32>(static_cast<u32>(renderTargetState.colorFormats.size()), 8); ++i)
+    {
+        result[i] = TextureFormatToDXGI(renderTargetState.colorFormats[i]);
+    }
+
+    // Fill remaining slots with UNKNOWN
+    for (u32 i = static_cast<u32>(renderTargetState.colorFormats.size()); i < 8; ++i)
+    {
+        result[i] = DXGI_FORMAT_UNKNOWN;
+    }
+
+    return result;
+}
+
+} // namespace GraphicsPipeline
+
+} // namespace vex::dx12

--- a/src/DX12/DX12GraphicsPipeline.h
+++ b/src/DX12/DX12GraphicsPipeline.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include <Vex/GraphicsPipeline.h>
+
+#include <DX12/DX12Headers.h>
+
+namespace vex::dx12
+{
+
+namespace GraphicsPipeline
+{
+
+D3D12_COMPARISON_FUNC GetD3D12ComparisonFuncFromCompareOp(CompareOp compareOp);
+D3D12_STENCIL_OP GetD3D12StencilOpFromStencilOp(StencilOp stencilOp);
+D3D12_BLEND GetD3D12BlendFromBlendFactor(BlendFactor blendFactor);
+D3D12_BLEND_OP GetD3D12BlendOpFromBlendOp(BlendOp blendOp);
+CD3DX12_RASTERIZER_DESC GetDX12RasterizerStateFromRasterizerState(const RasterizerState& rasterizerState);
+CD3DX12_BLEND_DESC GetDX12BlendStateFromColorBlendState(const ColorBlendState& blendState);
+D3D12_DEPTH_STENCIL_DESC GetDX12DepthStencilStateFromDepthStencilState(const DepthStencilState& depthStencilState);
+std::vector<D3D12_INPUT_ELEMENT_DESC> GetDX12InputElementDescFromVertexInputAssembly(
+    const VertexInputLayout& vertexInputLayout);
+D3D12_PRIMITIVE_TOPOLOGY GetDX12PrimitiveTopologyFromInputAssembly(const InputAssembly& inputAssembly);
+D3D12_PRIMITIVE_TOPOLOGY_TYPE GetDX12PrimitiveTopologyTypeFromInputAssembly(const InputAssembly& inputAssembly);
+u32 GetNumRenderTargetsFromRenderTargetState(const RenderTargetState& renderTargetState);
+std::array<DXGI_FORMAT, 8> GetRTVFormatsFromRenderTargetState(const RenderTargetState& renderTargetState);
+
+} // namespace GraphicsPipeline
+
+} // namespace vex::dx12

--- a/src/DX12/DX12PipelineState.cpp
+++ b/src/DX12/DX12PipelineState.cpp
@@ -63,11 +63,6 @@ void DX12GraphicsPipelineState::Compile(const RHIShader& vertexShader,
 #endif
 }
 
-bool DX12GraphicsPipelineState::NeedsRecompile(const Key& newKey)
-{
-    return false;
-}
-
 void DX12GraphicsPipelineState::Cleanup(ResourceCleanup& resourceCleanup)
 {
     // Simple swap and move

--- a/src/DX12/DX12PipelineState.cpp
+++ b/src/DX12/DX12PipelineState.cpp
@@ -1,18 +1,24 @@
 #include "DX12PipelineState.h"
 
 #include <Vex/Containers/ResourceCleanup.h>
+#include <Vex/GraphicsPipeline.h>
+#include <Vex/Logger.h>
+#include <Vex/Platform/Platform.h>
 #include <Vex/RHI/RHIBuffer.h>
 #include <Vex/RHI/RHIShader.h>
 #include <Vex/RHI/RHITexture.h>
 
+#include <DX12/DX12Formats.h>
+#include <DX12/DX12GraphicsPipeline.h>
 #include <DX12/DX12ResourceLayout.h>
 #include <DX12/HRChecker.h>
 
 namespace vex::dx12
 {
 
-DX12GraphicsPipelineState::DX12GraphicsPipelineState(const Key& key)
+DX12GraphicsPipelineState::DX12GraphicsPipelineState(const ComPtr<DX12Device>& device, const Key& key)
     : RHIGraphicsPipelineState(key)
+    , device(device)
 {
 }
 
@@ -22,26 +28,88 @@ void DX12GraphicsPipelineState::Compile(const RHIShader& vertexShader,
                                         const RHIShader& pixelShader,
                                         RHIResourceLayout& resourceLayout)
 {
-    // TODO: add missing fields to PSO key!
+    using namespace GraphicsPipeline;
+
     auto vsBlob = vertexShader.GetBlob();
     auto psBlob = pixelShader.GetBlob();
+    std::vector<D3D12_INPUT_ELEMENT_DESC> inputElementDesc =
+        GetDX12InputElementDescFromVertexInputAssembly(key.vertexInputLayout);
+    D3D12_INPUT_LAYOUT_DESC layoutDesc{ .pInputElementDescs = inputElementDesc.data(),
+                                        .NumElements = static_cast<u32>(inputElementDesc.size()) };
+    std::array<DXGI_FORMAT, 8> rtvFormats = GetRTVFormatsFromRenderTargetState(key.renderTargetState);
+
     D3D12_GRAPHICS_PIPELINE_STATE_DESC desc{
         .pRootSignature = reinterpret_cast<DX12ResourceLayout&>(resourceLayout).GetRootSignature().Get(),
         .VS = CD3DX12_SHADER_BYTECODE(vsBlob.data(), vsBlob.size()),
         .PS = CD3DX12_SHADER_BYTECODE(psBlob.data(), psBlob.size()),
-        .BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT),
-        .SampleMask = UINT_MAX,
-        .RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT),
-        .DepthStencilState = { .DepthEnable = false, .StencilEnable = false },
-        .InputLayout = { nullptr, 0 },
-        .PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
-        .NumRenderTargets = 1,
-        .RTVFormats = { DXGI_FORMAT_R8G8B8A8_UNORM },
+        .BlendState = GetDX12BlendStateFromColorBlendState(key.colorBlendState),
+        .SampleMask = UINT_MAX, // Vex does not support MSAA.
+        .RasterizerState = GetDX12RasterizerStateFromRasterizerState(key.rasterizerState),
+        .DepthStencilState = GetDX12DepthStencilStateFromDepthStencilState(key.depthStencilState),
+        .InputLayout = layoutDesc,
+        .PrimitiveTopologyType = GetDX12PrimitiveTopologyTypeFromInputAssembly(key.inputAssembly),
+        .NumRenderTargets = GetNumRenderTargetsFromRenderTargetState(key.renderTargetState),
         .SampleDesc = { .Count = 1 },
     };
-    // Temp for fullscreen triangle.
-    desc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+    std::uninitialized_copy_n(rtvFormats.data(), 8, desc.RTVFormats);
+    desc.DSVFormat = TextureFormatToDXGI(key.renderTargetState.depthStencilFormat);
+
+    chk << device->CreateGraphicsPipelineState(&desc, IID_PPV_ARGS(&graphicsPSO));
+
+#if !VEX_SHIPPING
+    graphicsPSO->SetName(StringToWString(std::format("{}", key)).c_str());
+#endif
 }
+
+bool DX12GraphicsPipelineState::NeedsRecompile(const Key& newKey)
+{
+    return false;
+}
+
+void DX12GraphicsPipelineState::Cleanup(ResourceCleanup& resourceCleanup)
+{
+    // Simple swap and move
+    auto cleanupPSO = MakeUnique<DX12GraphicsPipelineState>(device, key);
+    std::swap(cleanupPSO->graphicsPSO, graphicsPSO);
+    resourceCleanup.CleanupResource(std::move(cleanupPSO));
+}
+
+#define VEX_STRING(str) #str
+#define VEX_DECLARE_FIELD_CHECK(cond, fieldName, fieldValue)                                                           \
+    if ((cond))                                                                                                        \
+    {                                                                                                                  \
+        VEX_LOG(Fatal,                                                                                                 \
+                "Field " VEX_STRING(fieldName) " with value " VEX_STRING(fieldValue) " is unsupported in DX12.");      \
+    }
+
+void DX12GraphicsPipelineState::ValidateUnsupportedKeyFields(Key& key)
+{
+    auto IsNearlyZero = [](float num) { return std::abs(num) < std::numeric_limits<float>::epsilon(); };
+
+    VEX_DECLARE_FIELD_CHECK(key.inputAssembly.primitiveRestartEnabled, inputAssembly.primitiveRestartEnabled, true);
+    VEX_DECLARE_FIELD_CHECK(key.rasterizerState.depthClampEnabled, rasterizerState.depthClampEnabled, true);
+    VEX_DECLARE_FIELD_CHECK(key.rasterizerState.polygonMode == PolygonMode::Line,
+                            rasterizerState.polygonMode,
+                            PolygonMode::Line);
+    VEX_DECLARE_FIELD_CHECK(key.rasterizerState.polygonMode == PolygonMode::Point,
+                            rasterizerState.polygonMode,
+                            PolygonMode::Point);
+    VEX_DECLARE_FIELD_CHECK(!IsNearlyZero(key.rasterizerState.lineWidth), rasterizerState.lineWidth, different to 0);
+    VEX_DECLARE_FIELD_CHECK(key.depthStencilState.front.reference, depthStencilState.front.reference, different to 0);
+    VEX_DECLARE_FIELD_CHECK(key.depthStencilState.back.reference, depthStencilState.back.reference, different to 0);
+    VEX_DECLARE_FIELD_CHECK(!IsNearlyZero(key.depthStencilState.minDepthBounds),
+                            depthStencilState.minDepthBounds,
+                            different to 0);
+    VEX_DECLARE_FIELD_CHECK(!IsNearlyZero(key.depthStencilState.maxDepthBounds),
+                            depthStencilState.maxDepthBounds,
+                            different to 0);
+    VEX_DECLARE_FIELD_CHECK(key.colorBlendState.logicOpEnabled, colorBlendState.logicOpEnabled, true);
+    // Forced to LogicOp::Clear, just to keep the key's hash consistent.
+    key.colorBlendState.logicOp = LogicOp::Clear;
+}
+
+#undef VEX_DECLARE_FIELD_CHECK
+#undef VEX_STRING
 
 DX12ComputePipelineState::DX12ComputePipelineState(const ComPtr<DX12Device>& device, const Key& key)
     : RHIComputePipelineState(key)

--- a/src/DX12/DX12PipelineState.cpp
+++ b/src/DX12/DX12PipelineState.cpp
@@ -50,6 +50,8 @@ void DX12GraphicsPipelineState::Compile(const RHIShader& vertexShader,
         .PrimitiveTopologyType = GetDX12PrimitiveTopologyTypeFromInputAssembly(key.inputAssembly),
         .NumRenderTargets = GetNumRenderTargetsFromRenderTargetState(key.renderTargetState),
         .SampleDesc = { .Count = 1 },
+        .NodeMask = 0,
+        .Flags = D3D12_PIPELINE_STATE_FLAG_NONE,
     };
     std::uninitialized_copy_n(rtvFormats.data(), 8, desc.RTVFormats);
     desc.DSVFormat = TextureFormatToDXGI(key.renderTargetState.depthStencilFormat);

--- a/src/DX12/DX12PipelineState.h
+++ b/src/DX12/DX12PipelineState.h
@@ -15,7 +15,6 @@ public:
     virtual void Compile(const RHIShader& vertexShader,
                          const RHIShader& pixelShader,
                          RHIResourceLayout& resourceLayout) override;
-    virtual bool NeedsRecompile(const Key& newKey) override;
     virtual void Cleanup(ResourceCleanup& resourceCleanup) override;
 
     // Verifies that the key does not contain fields with non-default values for features which DX12 does not support.

--- a/src/DX12/DX12PipelineState.h
+++ b/src/DX12/DX12PipelineState.h
@@ -10,13 +10,22 @@ namespace vex::dx12
 class DX12GraphicsPipelineState : public RHIGraphicsPipelineState
 {
 public:
-    DX12GraphicsPipelineState(const Key& key);
+    DX12GraphicsPipelineState(const ComPtr<DX12Device>& device, const Key& key);
     virtual ~DX12GraphicsPipelineState() override;
     virtual void Compile(const RHIShader& vertexShader,
                          const RHIShader& pixelShader,
                          RHIResourceLayout& resourceLayout) override;
+    virtual bool NeedsRecompile(const Key& newKey) override;
+    virtual void Cleanup(ResourceCleanup& resourceCleanup) override;
+
+    // Verifies that the key does not contain fields with non-default values for features which DX12 does not support.
+    // Clears the unused fields which allows for changes to these fields to not impact the hash of the structure.
+    static void ValidateUnsupportedKeyFields(Key& key);
 
     ComPtr<ID3D12PipelineState> graphicsPSO;
+
+private:
+    ComPtr<DX12Device> device;
 };
 
 class DX12ComputePipelineState : public RHIComputePipelineState

--- a/src/DX12/DX12PipelineState.h
+++ b/src/DX12/DX12PipelineState.h
@@ -20,7 +20,7 @@ public:
 
     // Verifies that the key does not contain fields with non-default values for features which DX12 does not support.
     // Clears the unused fields which allows for changes to these fields to not impact the hash of the structure.
-    static void ValidateUnsupportedKeyFields(Key& key);
+    static void ClearUnsupportedKeyFields(Key& key);
 
     ComPtr<ID3D12PipelineState> graphicsPSO;
 

--- a/src/DX12/DX12RHI.cpp
+++ b/src/DX12/DX12RHI.cpp
@@ -137,7 +137,10 @@ UniqueHandle<RHIShader> DX12RHI::CreateShader(const ShaderKey& key)
 
 UniqueHandle<RHIGraphicsPipelineState> DX12RHI::CreateGraphicsPipelineState(const GraphicsPipelineStateKey& key)
 {
-    return MakeUnique<DX12GraphicsPipelineState>(key);
+    GraphicsPipelineStateKey keyCopy = key;
+    // Will clear out unsupported fields/validate that the user is not expecting invalid features.
+    DX12GraphicsPipelineState::ValidateUnsupportedKeyFields(keyCopy);
+    return MakeUnique<DX12GraphicsPipelineState>(device, std::move(keyCopy));
 }
 
 UniqueHandle<RHIComputePipelineState> DX12RHI::CreateComputePipelineState(const ComputePipelineStateKey& key)
@@ -181,6 +184,7 @@ void DX12RHI::WaitFence(CommandQueueType queueType, RHIFence& fence, u32 fenceIn
 {
     chk << GetQueue(queueType)->Wait(static_cast<DX12Fence&>(fence).fence.Get(), fence.GetFenceValue(fenceIndex));
 }
+
 void DX12RHI::ModifyShaderCompilerEnvironment(std::vector<const wchar_t*>& args, std::vector<ShaderDefine>& defines)
 {
     args.push_back(L"-Qstrip_reflect");

--- a/src/DX12/DX12RHI.cpp
+++ b/src/DX12/DX12RHI.cpp
@@ -139,7 +139,7 @@ UniqueHandle<RHIGraphicsPipelineState> DX12RHI::CreateGraphicsPipelineState(cons
 {
     GraphicsPipelineStateKey keyCopy = key;
     // Will clear out unsupported fields/validate that the user is not expecting invalid features.
-    DX12GraphicsPipelineState::ValidateUnsupportedKeyFields(keyCopy);
+    DX12GraphicsPipelineState::ClearUnsupportedKeyFields(keyCopy);
     return MakeUnique<DX12GraphicsPipelineState>(device, std::move(keyCopy));
 }
 

--- a/src/DX12/DX12ResourceLayout.cpp
+++ b/src/DX12/DX12ResourceLayout.cpp
@@ -5,6 +5,8 @@
 
 #include <Vex/Logger.h>
 
+#include <Vex/Platform/Windows/HResult.h>
+
 #include <DX12/HRChecker.h>
 
 namespace vex::dx12
@@ -90,14 +92,18 @@ void DX12ResourceLayout::CompileRootSignature()
 
     ComPtr<ID3DBlob> signature;
     ComPtr<ID3DBlob> error;
-    chkSoft << D3D12SerializeRootSignature(&rootSignatureDesc,
-                                           D3D_ROOT_SIGNATURE_VERSION_1,
-                                           signature.GetAddressOf(),
-                                           error.GetAddressOf());
+    HRESULT hr = D3D12SerializeRootSignature(&rootSignatureDesc,
+                                             D3D_ROOT_SIGNATURE_VERSION_1,
+                                             signature.GetAddressOf(),
+                                             error.GetAddressOf());
     if (error)
     {
         const char* errorMessage = static_cast<const char*>(error->GetBufferPointer());
         VEX_LOG(Fatal, "Error serializing root signature: {}", errorMessage);
+    }
+    else if (FAILED(hr))
+    {
+        VEX_LOG(Fatal, "Unspecified error serializing root signature: {}", HRToError(hr));
     }
 
     chk << device->CreateRootSignature(0,

--- a/src/DX12/DX12Texture.cpp
+++ b/src/DX12/DX12Texture.cpp
@@ -2,6 +2,7 @@
 
 #include <magic_enum/magic_enum.hpp>
 
+#include <Vex/Bindings.h>
 #include <Vex/Logger.h>
 #include <Vex/Platform/Windows/WString.h>
 #include <Vex/RHI/RHIDescriptorPool.h>
@@ -242,7 +243,7 @@ DX12Texture::DX12Texture(ComPtr<DX12Device>& device, const TextureDescription& d
     static const D3D12_HEAP_PROPERTIES heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
 
     D3D12_CLEAR_VALUE* clearValue = nullptr;
-    if (description.clearValue.enabled)
+    if (description.clearValue.flags != TextureClear::None)
     {
         *clearValue = {};
         clearValue->Format = texDesc.Format;
@@ -422,6 +423,19 @@ BindlessHandle DX12Texture::GetOrCreateBindlessView(ComPtr<DX12Device>& device,
 
         return handle;
     }
+}
+
+DX12TextureView::DX12TextureView(const ResourceBinding& binding,
+                                 const TextureDescription& description,
+                                 ResourceUsage::Type usage)
+    : type{ usage }
+    , dimension{ TextureUtil::GetTextureViewType(binding) }
+    , format{ TextureFormatToDXGI(TextureUtil::GetTextureFormat(binding)) }
+    , mipBias{ binding.mipBias }
+    , mipCount{ (binding.mipCount == 0) ? description.mips : binding.mipCount }
+    , startSlice{ binding.startSlice }
+    , sliceCount{ (binding.sliceCount == 0) ? description.depthOrArraySize : binding.sliceCount }
+{
 }
 
 } // namespace vex::dx12

--- a/src/DX12/DX12Texture.h
+++ b/src/DX12/DX12Texture.h
@@ -10,11 +10,17 @@
 #include <DX12/DX12DescriptorPool.h>
 #include <DX12/DX12Headers.h>
 
+namespace vex
+{
+struct ResourceBinding;
+}
+
 namespace vex::dx12
 {
 
 struct DX12TextureView
 {
+    DX12TextureView(const ResourceBinding& binding, const TextureDescription& description, ResourceUsage::Type usage);
     ResourceUsage::Type type;
     TextureViewType dimension;
     // Uses the underlying resource's format if set to DXGI_FORMAT_UNKNOWN (and if the texture's format is not

--- a/src/Vex.h
+++ b/src/Vex.h
@@ -2,6 +2,7 @@
 
 #include <Vex/Bindings.h>
 #include <Vex/CommandContext.h>
+#include <Vex/DrawHelpers.h>
 #include <Vex/FeatureChecker.h>
 #include <Vex/GfxBackend.h>
 

--- a/src/Vex/Bindings.h
+++ b/src/Vex/Bindings.h
@@ -33,7 +33,7 @@ END_VEX_ENUM_FLAGS();
 // Flags for a texture binding.
 BEGIN_VEX_ENUM_FLAGS(TextureBinding, u8)
     None,
-    SRGB,
+    SRGB = 1,
 END_VEX_ENUM_FLAGS();
 
 // clang-format on

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -15,6 +15,7 @@ class GfxBackend;
 struct ConstantBinding;
 struct ResourceBinding;
 struct Texture;
+struct TextureClearValue;
 
 struct DrawDescription
 {
@@ -40,6 +41,15 @@ public:
 
     CommandContext(CommandContext&& other) = default;
     CommandContext& operator=(CommandContext&& other) = default;
+
+    void SetViewport(float x, float y, float width, float height, float minDepth = 0.0f, float maxDepth = 1.0f);
+    void SetScissor(i32 x, i32 y, u32 width, u32 height);
+
+    // Clears a texture, by default will use the texture's ClearColor.
+    void ClearTexture(
+        ResourceBinding binding,
+        TextureClearValue* optionalTextureClearValue = nullptr, // Use ptr to allow for fwd declaration of type.
+        std::optional<std::array<float, 4>> clearRect = std::nullopt);
 
     void Draw(const DrawDescription& drawDesc,
               std::span<const ConstantBinding> constants,

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -2,6 +2,7 @@
 
 #include <span>
 
+#include <Vex/GraphicsPipeline.h>
 #include <Vex/RHI/RHIFwd.h>
 #include <Vex/ShaderKey.h>
 #include <Vex/Types.h>
@@ -19,6 +20,13 @@ struct DrawDescription
 {
     ShaderKey vertexShader;
     ShaderKey pixelShader;
+    VertexInputLayout vertexInputLayout;
+    InputAssembly inputAssembly;
+    RasterizerState rasterizerState;
+    DepthStencilState depthStencilState;
+    ColorBlendState colorBlendState;
+
+    bool operator==(const DrawDescription& other) const = default;
 };
 
 class CommandContext
@@ -36,6 +44,7 @@ public:
     void Draw(const DrawDescription& drawDesc,
               std::span<const ConstantBinding> constants,
               std::span<const ResourceBinding> reads,
+              std::span<const ResourceBinding> readWrites,
               std::span<const ResourceBinding> writes,
               u32 vertexCount);
 
@@ -49,7 +58,7 @@ public:
     void Dispatch(const ShaderKey& shader,
                   std::span<const ConstantBinding> constants,
                   std::span<const ResourceBinding> reads,
-                  std::span<const ResourceBinding> writes,
+                  std::span<const ResourceBinding> readWrites,
                   std::array<u32, 3> groupCount);
 
     void Copy(const Texture& source, const Texture& destination);

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <span>
 
 #include <Vex/GraphicsPipeline.h>
@@ -16,19 +17,8 @@ struct ConstantBinding;
 struct ResourceBinding;
 struct Texture;
 struct TextureClearValue;
-
-struct DrawDescription
-{
-    ShaderKey vertexShader;
-    ShaderKey pixelShader;
-    VertexInputLayout vertexInputLayout;
-    InputAssembly inputAssembly;
-    RasterizerState rasterizerState;
-    DepthStencilState depthStencilState;
-    ColorBlendState colorBlendState;
-
-    bool operator==(const DrawDescription& other) const = default;
-};
+struct DrawDescription;
+struct DrawResources;
 
 class CommandContext
 {
@@ -46,17 +36,12 @@ public:
     void SetScissor(i32 x, i32 y, u32 width, u32 height);
 
     // Clears a texture, by default will use the texture's ClearColor.
-    void ClearTexture(
-        ResourceBinding binding,
-        TextureClearValue* optionalTextureClearValue = nullptr, // Use ptr to allow for fwd declaration of type.
-        std::optional<std::array<float, 4>> clearRect = std::nullopt);
+    void ClearTexture(ResourceBinding binding,
+                      TextureClearValue* optionalTextureClearValue =
+                          nullptr, // Use ptr instead of optional to allow for fwd declaration of type.
+                      std::optional<std::array<float, 4>> clearRect = std::nullopt);
 
-    void Draw(const DrawDescription& drawDesc,
-              std::span<const ConstantBinding> constants,
-              std::span<const ResourceBinding> reads,
-              std::span<const ResourceBinding> readWrites,
-              std::span<const ResourceBinding> writes,
-              u32 vertexCount);
+    void Draw(const DrawDescription& drawDesc, const DrawResources& drawResources, u32 vertexCount);
 
     void DrawIndexed()
     {

--- a/src/Vex/DrawHelpers.h
+++ b/src/Vex/DrawHelpers.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <optional>
+#include <span>
+
+#include <Vex/Bindings.h>
+#include <Vex/GraphicsPipeline.h>
+#include <Vex/ShaderKey.h>
+
+namespace vex
+{
+
+struct DrawDescription
+{
+    ShaderKey vertexShader;
+    ShaderKey pixelShader;
+    VertexInputLayout vertexInputLayout;
+    InputAssembly inputAssembly;
+    RasterizerState rasterizerState;
+    DepthStencilState depthStencilState;
+    ColorBlendState colorBlendState;
+
+    bool operator==(const DrawDescription& other) const = default;
+};
+
+struct DrawResources
+{
+    // Local constants bound to the root/push constants of your pass.
+    std::span<const ConstantBinding> constants;
+    // Read-only resources.
+    std::span<const ResourceBinding> readResources;
+    // Read / Write resources.
+    std::span<const ResourceBinding> unorderedAccessResources;
+    // Write-only resources.
+    std::span<const ResourceBinding> renderTargets;
+    // Write-only resource (optional).
+    std::optional<ResourceBinding> depthStencil = std::nullopt;
+
+    bool operator==(const DrawResources& other) const = default;
+};
+
+} // namespace vex

--- a/src/Vex/DrawHelpers.h
+++ b/src/Vex/DrawHelpers.h
@@ -19,8 +19,6 @@ struct DrawDescription
     RasterizerState rasterizerState;
     DepthStencilState depthStencilState;
     ColorBlendState colorBlendState;
-
-    bool operator==(const DrawDescription& other) const = default;
 };
 
 struct DrawResources
@@ -35,8 +33,6 @@ struct DrawResources
     std::span<const ResourceBinding> renderTargets;
     // Write-only resource (optional).
     std::optional<ResourceBinding> depthStencil = std::nullopt;
-
-    bool operator==(const DrawResources& other) const = default;
 };
 
 } // namespace vex

--- a/src/Vex/Formats.cpp
+++ b/src/Vex/Formats.cpp
@@ -42,7 +42,6 @@ bool IsFormatSRGB(TextureFormat format)
     default:
         return false;
     }
-    std::unreachable();
 }
 
 bool FormatHasSRGBEquivalent(TextureFormat format)
@@ -59,7 +58,20 @@ bool FormatHasSRGBEquivalent(TextureFormat format)
     default:
         return false;
     }
-    std::unreachable();
+}
+
+bool FormatIsDepthStencilCompatible(TextureFormat format)
+{
+    switch (format)
+    {
+    case TextureFormat::D16_UNORM:
+    case TextureFormat::D24_UNORM_S8_UINT:
+    case TextureFormat::D32_FLOAT_S8_UINT:
+    case TextureFormat::D32_FLOAT:
+        return true;
+    default:
+        return false;
+    }
 }
 
 } // namespace vex

--- a/src/Vex/Formats.h
+++ b/src/Vex/Formats.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Vex/Hash.h>
 #include <Vex/Types.h>
 
 namespace vex
@@ -86,4 +87,14 @@ bool IsFormatSRGB(TextureFormat format);
 
 bool FormatHasSRGBEquivalent(TextureFormat format);
 
+bool FormatIsDepthStencilCompatible(TextureFormat format);
+
 } // namespace vex
+
+// clang-format off
+
+VEX_MAKE_HASHABLE(vex::TextureFormat,
+    VEX_HASH_COMBINE_ENUM(seed, obj);
+);
+
+// clang-format on

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -1,6 +1,7 @@
 #include "GfxBackend.h"
 
 #include <algorithm>
+#include <utility>
 
 #include <magic_enum/magic_enum.hpp>
 
@@ -152,6 +153,8 @@ void GfxBackend::EndCommandContext(RHICommandList& cmdList)
     cmdList.Transition(transitions);
 
     cmdList.Close();
+    // TODO(https://trello.com/c/yrO8xMkU): change command list execution to be done in one batch at the end of the
+    // frame (more efficient according to AMD's performance guide).
     rhi->ExecuteCommandList(cmdList);
 }
 

--- a/src/Vex/GraphicsPipeline.h
+++ b/src/Vex/GraphicsPipeline.h
@@ -1,0 +1,359 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include <Vex/EnumFlags.h>
+#include <Vex/Formats.h>
+#include <Vex/Hash.h>
+#include <Vex/Types.h>
+
+namespace vex
+{
+
+struct VertexInputLayout
+{
+    struct VertexAttribute
+    {
+        std::string semanticName; // eg: "TEXCOORD", "POSITION", "NORMAL", etc...
+        u32 semanticIndex;        // 0, 1, 2, etc...
+        u32 binding;
+        TextureFormat format;
+        u32 offset;
+
+        bool operator==(const VertexAttribute& other) const = default;
+    };
+
+    enum InputRate : u8
+    {
+        PerVertex,
+        PerInstance,
+    };
+
+    struct VertexBinding
+    {
+        u32 binding;
+        u32 stride;
+        InputRate inputRate;
+
+        bool operator==(const VertexBinding& other) const = default;
+    };
+
+    std::vector<VertexAttribute> attributes;
+    std::vector<VertexBinding> bindings;
+
+    bool operator==(const VertexInputLayout& other) const = default;
+};
+
+enum class InputTopology : u8
+{
+    TriangleList,
+    TriangleStrip,
+    TriangleFan,
+};
+
+struct InputAssembly
+{
+    InputTopology topology = InputTopology::TriangleList;
+    bool primitiveRestartEnabled = false; // Vulkan only
+
+    bool operator==(const InputAssembly& other) const = default;
+};
+
+enum class CullMode : u8
+{
+    None,
+    Front,
+    Back,
+};
+
+enum class PolygonMode : u8
+{
+    Fill,
+    Line,  // Vulkan only
+    Point, // Vulkan only
+};
+
+enum class FillMode : u8
+{
+    Wireframe,
+    Solid,
+};
+
+enum class Winding : u8
+{
+    CounterClockwise,
+    Clockwise,
+};
+
+struct RasterizerState
+{
+    bool rasterizerDiscardEnabled = false;
+    bool depthClampEnabled = false; // Vulkan only
+    PolygonMode polygonMode = PolygonMode::Fill;
+    CullMode cullMode = CullMode::Back;
+    Winding winding = Winding::CounterClockwise;
+    bool depthBiasEnabled = false;
+    float depthBiasConstantFactor = 0;
+    float depthBiasClamp = 0;
+    float depthBiasSlopeFactor = 0;
+    float lineWidth = 0; // Vulkan only
+
+    bool operator==(const RasterizerState& other) const = default;
+};
+
+// Note: for now Multisampling is unsupported in Vex. If the need ever arises it would be trivial to add.
+
+// See this for an explanation of each operation:
+// https://registry.khronos.org/vulkan/specs/latest/man/html/VkCompareOp.html#_description
+// Mapping is 1:1 between DX12 and Vulkan (dx12 enum value is the vulkan enum value + 1).
+enum class CompareOp : u8
+{
+    Never,
+    Less,
+    Equal,
+    LessEqual,
+    Greater,
+    NotEqual,
+    GreaterEqual,
+    Always,
+    None = 99,
+};
+
+// See this for an explanation of each operation:
+// https://registry.khronos.org/vulkan/specs/latest/man/html/VkStencilOp.html#_description
+// Mapping is 1:1 between DX12 and Vulkan (dx12 enum value is the vulkan enum value + 1).
+enum class StencilOp : u8
+{
+    Keep,
+    Zero,
+    Replace,
+    IncrementClamp,
+    DecrementClamp,
+    Invert,
+    IncrementWrap,
+    DecrementWrap,
+};
+
+struct DepthStencilState
+{
+    bool depthTestEnabled = false;
+    bool depthWriteEnabled = false;
+    CompareOp depthCompareOp = CompareOp::None;
+    bool depthBoundsTestEnabled = false; // Vulkan only
+    struct StencilOpState
+    {
+        StencilOp failOp = StencilOp::Keep;
+        StencilOp passOp = StencilOp::Keep;
+        StencilOp depthFailOp = StencilOp::Keep;
+        CompareOp compareOp = CompareOp::Never;
+        u32 readMask = 0;  // Only u8 in DX12
+        u32 writeMask = 0; // Only u8 in DX12
+        u32 reference = 0; // Vulkan only
+
+        bool operator==(const StencilOpState& other) const = default;
+    };
+    StencilOpState front;
+    StencilOpState back;
+    float minDepthBounds = 0; // Vulkan only
+    float maxDepthBounds = 0; // Vulkan only
+
+    bool operator==(const DepthStencilState& other) const = default;
+};
+
+// See the following link for an explanation of each step:
+// https://registry.khronos.org/vulkan/specs/latest/man/html/VkLogicOp.html#_description
+// This is a Vulkan-only concept.
+enum class LogicOp : u8
+{
+    Clear,
+    And,
+    AndReverse,
+    Copy,
+    AndInverted,
+    NoOp,
+    Xor,
+    Or,
+    Nor,
+    Equivalent,
+    Invert,
+    OrReverse,
+    CopyInverted,
+    OrInverted,
+    Nand,
+    Set,
+};
+
+// See the following link for more info:
+// https://registry.khronos.org/vulkan/specs/latest/man/html/VkBlendFactor.html#_description
+// This one has the same values in DX12 and Vulkan, but ordered differently...
+enum class BlendFactor : u8
+{
+    Zero,
+    One,
+    SrcColor,
+    OneMinusSrcColor,
+    DstColor,
+    OneMinusDstColor,
+    SrcAlpha,
+    OneMinusSrcAlpha,
+    DstAlpha,
+    OneMinusDstAlpha,
+    ConstantColor,
+    OneMinusConstantColor,
+    ConstantAlpha,
+    OneMinusConstantAlpha,
+    SrcAlphaSaturate,
+    Src1Color,
+    OneMinusSrc1Color,
+    Src1Alpha,
+    OneMinusSrc1Alpha,
+};
+
+// See the following link for more info:
+// https://registry.khronos.org/vulkan/specs/latest/man/html/VkBlendOp.html#_description
+// The mapping is 1:1 here between DX12 and Vulkan (dx12 enum = vulkan enum + 1).
+enum class BlendOp : u8
+{
+    Add,
+    Subtract,
+    ReverseSubtract,
+    Min,
+    Max,
+};
+
+// clang-format off
+
+// Flags for which channels are written to the render target.
+BEGIN_VEX_ENUM_FLAGS(ColorWriteMask, u8)
+    None,
+    Red = 1,
+    Green = 2,
+    Blue = 4,
+    Alpha = 8,
+    All = 0b1111,
+END_VEX_ENUM_FLAGS();
+
+// clang-format on
+
+struct ColorBlendState
+{
+    bool logicOpEnabled = false;      // Vulkan only
+    LogicOp logicOp = LogicOp::Clear; // Vulkan only
+
+    struct ColorBlendAttachment
+    {
+        bool blendEnabled = false;
+        BlendFactor srcColorBlendFactor;
+        BlendFactor dstColorBlendFactor;
+        BlendOp colorBlendOp;
+        BlendFactor srcAlphaBlendFactor;
+        BlendFactor dstAlphaBlendFactor;
+        BlendOp alphaBlendOp;
+        ColorWriteMask::Flags colorWriteMask;
+
+        bool operator==(const ColorBlendAttachment& other) const = default;
+    };
+
+    // One blend attachment per render target.
+    std::vector<ColorBlendAttachment> attachments;
+    std::array<float, 4> blendConstants{};
+
+    bool operator==(const ColorBlendState& other) const = default;
+};
+
+struct RenderTargetState
+{
+    std::vector<TextureFormat> colorFormats;
+    TextureFormat depthStencilFormat;
+
+    bool operator==(const RenderTargetState& other) const = default;
+};
+
+} // namespace vex
+
+// clang-format off
+
+VEX_MAKE_HASHABLE(vex::VertexInputLayout::VertexAttribute,
+    VEX_HASH_COMBINE(seed, obj.binding);
+    VEX_HASH_COMBINE_ENUM(seed, obj.format);
+    VEX_HASH_COMBINE(seed, obj.offset);
+    VEX_HASH_COMBINE(seed, obj.semanticName);
+    VEX_HASH_COMBINE(seed, obj.semanticIndex);
+);
+
+VEX_MAKE_HASHABLE(vex::VertexInputLayout::VertexBinding,
+    VEX_HASH_COMBINE(seed, obj.binding);
+    VEX_HASH_COMBINE(seed, obj.stride);
+    VEX_HASH_COMBINE_ENUM(seed, obj.inputRate);
+);
+
+VEX_MAKE_HASHABLE(vex::VertexInputLayout,
+    VEX_HASH_COMBINE_CONTAINER(seed, obj.attributes);
+    VEX_HASH_COMBINE_CONTAINER(seed, obj.bindings);
+);
+
+VEX_MAKE_HASHABLE(vex::InputAssembly,
+    VEX_HASH_COMBINE_ENUM(seed, obj.topology);
+    VEX_HASH_COMBINE(seed, obj.primitiveRestartEnabled);
+);
+
+VEX_MAKE_HASHABLE(vex::RasterizerState,
+    VEX_HASH_COMBINE(seed, obj.rasterizerDiscardEnabled);
+    VEX_HASH_COMBINE(seed, obj.depthClampEnabled);
+    VEX_HASH_COMBINE_ENUM(seed, obj.polygonMode);
+    VEX_HASH_COMBINE_ENUM(seed, obj.cullMode);
+    VEX_HASH_COMBINE_ENUM(seed, obj.winding);
+    VEX_HASH_COMBINE(seed, obj.depthBiasEnabled);
+    VEX_HASH_COMBINE(seed, obj.depthBiasConstantFactor);
+    VEX_HASH_COMBINE(seed, obj.depthBiasClamp);
+    VEX_HASH_COMBINE(seed, obj.depthBiasSlopeFactor);
+    VEX_HASH_COMBINE(seed, obj.lineWidth);
+);
+
+VEX_MAKE_HASHABLE(vex::DepthStencilState::StencilOpState,
+    VEX_HASH_COMBINE_ENUM(seed, obj.failOp);
+    VEX_HASH_COMBINE_ENUM(seed, obj.passOp);
+    VEX_HASH_COMBINE_ENUM(seed, obj.depthFailOp);
+    VEX_HASH_COMBINE_ENUM(seed, obj.compareOp);
+    VEX_HASH_COMBINE(seed, obj.readMask);
+    VEX_HASH_COMBINE(seed, obj.writeMask);
+    VEX_HASH_COMBINE(seed, obj.reference);
+);
+
+VEX_MAKE_HASHABLE(vex::DepthStencilState,
+    VEX_HASH_COMBINE(seed, obj.depthTestEnabled);
+    VEX_HASH_COMBINE(seed, obj.depthWriteEnabled);
+    VEX_HASH_COMBINE_ENUM(seed, obj.depthCompareOp);
+    VEX_HASH_COMBINE(seed, obj.depthBoundsTestEnabled);
+    VEX_HASH_COMBINE(seed, obj.front);
+    VEX_HASH_COMBINE(seed, obj.back);
+    VEX_HASH_COMBINE(seed, obj.minDepthBounds);
+    VEX_HASH_COMBINE(seed, obj.maxDepthBounds);
+);
+
+VEX_MAKE_HASHABLE(vex::ColorBlendState::ColorBlendAttachment,
+    VEX_HASH_COMBINE(seed, obj.blendEnabled);
+    VEX_HASH_COMBINE_ENUM(seed, obj.srcColorBlendFactor);
+    VEX_HASH_COMBINE_ENUM(seed, obj.dstColorBlendFactor);
+    VEX_HASH_COMBINE_ENUM(seed, obj.colorBlendOp);
+    VEX_HASH_COMBINE_ENUM(seed, obj.srcAlphaBlendFactor);
+    VEX_HASH_COMBINE_ENUM(seed, obj.dstAlphaBlendFactor);
+    VEX_HASH_COMBINE_ENUM(seed, obj.alphaBlendOp);
+    VEX_HASH_COMBINE(seed, obj.colorWriteMask);
+);
+
+VEX_MAKE_HASHABLE(vex::ColorBlendState,
+    VEX_HASH_COMBINE(seed, obj.logicOpEnabled);
+    VEX_HASH_COMBINE_ENUM(seed, obj.logicOp);
+    VEX_HASH_COMBINE_CONTAINER(seed, obj.attachments);
+    VEX_HASH_COMBINE_CONTAINER(seed, obj.blendConstants);
+);
+
+VEX_MAKE_HASHABLE(vex::RenderTargetState,
+    VEX_HASH_COMBINE_CONTAINER(seed, obj.colorFormats);
+    VEX_HASH_COMBINE_ENUM(seed, obj.depthStencilFormat);
+);
+
+// clang-format on

--- a/src/Vex/GraphicsPipeline.h
+++ b/src/Vex/GraphicsPipeline.h
@@ -147,7 +147,7 @@ struct DepthStencilState
         StencilOp failOp = StencilOp::Keep;
         StencilOp passOp = StencilOp::Keep;
         StencilOp depthFailOp = StencilOp::Keep;
-        CompareOp compareOp = CompareOp::Never;
+        CompareOp compareOp = CompareOp::Always;
         u32 readMask = 0;  // Only u8 in DX12
         u32 writeMask = 0; // Only u8 in DX12
         u32 reference = 0; // Vulkan only
@@ -245,13 +245,13 @@ struct ColorBlendState
     struct ColorBlendAttachment
     {
         bool blendEnabled = false;
-        BlendFactor srcColorBlendFactor;
-        BlendFactor dstColorBlendFactor;
-        BlendOp colorBlendOp;
-        BlendFactor srcAlphaBlendFactor;
-        BlendFactor dstAlphaBlendFactor;
-        BlendOp alphaBlendOp;
-        ColorWriteMask::Flags colorWriteMask;
+        BlendFactor srcColorBlendFactor = BlendFactor::One;
+        BlendFactor dstColorBlendFactor = BlendFactor::Zero;
+        BlendOp colorBlendOp = BlendOp::Add;
+        BlendFactor srcAlphaBlendFactor = BlendFactor::One;
+        BlendFactor dstAlphaBlendFactor = BlendFactor::Zero;
+        BlendOp alphaBlendOp = BlendOp::Add;
+        ColorWriteMask::Flags colorWriteMask = ColorWriteMask::All;
 
         bool operator==(const ColorBlendAttachment& other) const = default;
     };

--- a/src/Vex/Hash.h
+++ b/src/Vex/Hash.h
@@ -4,19 +4,19 @@
 
 // Base macro for combining hashes
 #define VEX_HASH_COMBINE(seed, value)                                                                                  \
-    (seed) ^= std::hash<decltype(value)>()(value) + 0x9e3779b9 + ((seed) << 6) + ((seed) >> 2)
+    (seed) ^= std::hash<std::remove_const_t<std::remove_reference_t<decltype(value)>>>()(value) + 0x9e3779b9 +         \
+              ((seed) << 6) + ((seed) >> 2)
 
-// Macro for hashing an enum using magic_enum
+// Macro for hashing an enum using the string provided by magic_enum
 #define VEX_HASH_COMBINE_ENUM(seed, enum_value)                                                                        \
     (seed) ^= std::hash<std::string>()(std::string(magic_enum::enum_name(enum_value))) + 0x9e3779b9 + ((seed) << 6) +  \
               ((seed) >> 2)
 
 // Macro for hashing a container (vector, array, etc.)
-// Won't work for more than 1 level of depth (eg container inside container)
-#define VEX_HASH_COMBINE_CONTAINER(seed, container, ...)                                                               \
+#define VEX_HASH_COMBINE_CONTAINER(seed, container)                                                                    \
     for (const auto& item : container)                                                                                 \
     {                                                                                                                  \
-        __VA_ARGS__;                                                                                                   \
+        VEX_HASH_COMBINE(seed, item);                                                                                  \
     }
 
 // Macro to generate hash function for a struct or class

--- a/src/Vex/Platform/Platform.h
+++ b/src/Vex/Platform/Platform.h
@@ -1,7 +1,16 @@
 #pragma once
 
 #if defined(_WIN32)
+
 #include <Vex/Platform/Windows/WString.h>
+
 #elif defined(__linux__)
+
 #include <Vex/Platform/Linux/WString.h>
+
+// X11 defines a macro called "Always"
+#if defined(Always)
+#undef Always
+#endif // defined(Always)
+
 #endif

--- a/src/Vex/Platform/Platform.h
+++ b/src/Vex/Platform/Platform.h
@@ -8,9 +8,4 @@
 
 #include <Vex/Platform/Linux/WString.h>
 
-// X11 defines a macro called "Always"
-#if defined(Always)
-#undef Always
-#endif // defined(Always)
-
 #endif

--- a/src/Vex/RHI/RHICommandList.h
+++ b/src/Vex/RHI/RHICommandList.h
@@ -45,6 +45,10 @@ public:
     virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout) = 0;
     virtual void SetInputAssembly(InputAssembly inputAssembly) = 0;
 
+    virtual void ClearTexture(RHITexture& rhiTexture,
+                              const ResourceBinding& clearBinding,
+                              const TextureClearValue& clearValue) = 0;
+
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) = 0;
     // Ideal for batching multiple resource transitions together.
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) = 0;

--- a/src/Vex/RHI/RHICommandList.h
+++ b/src/Vex/RHI/RHICommandList.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <array>
 #include <span>
 #include <utility>
@@ -17,6 +16,7 @@ class RHITexture;
 class RHIBuffer;
 struct RHITextureBinding;
 struct RHIBufferBinding;
+struct InputAssembly;
 
 class RHICommandList
 {
@@ -43,10 +43,13 @@ public:
                                     std::span<RHIBufferBinding> buffers,
                                     RHIDescriptorPool& descriptorPool) = 0;
     virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout) = 0;
+    virtual void SetInputAssembly(InputAssembly inputAssembly) = 0;
 
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) = 0;
     // Ideal for batching multiple resource transitions together.
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) = 0;
+
+    virtual void Draw(u32 vertexCount) = 0;
 
     virtual void Dispatch(const std::array<u32, 3>& groupCount) = 0;
 

--- a/src/Vex/RHI/RHIPipelineState.h
+++ b/src/Vex/RHI/RHIPipelineState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Vex/GraphicsPipeline.h>
 #include <Vex/Hash.h>
 #include <Vex/RHI/RHIFwd.h>
 #include <Vex/ShaderKey.h>
@@ -14,7 +15,13 @@ struct GraphicsPipelineStateKey
 {
     ShaderKey vertexShader;
     ShaderKey pixelShader;
-    // TODO: finish graphics pipeline state key
+    VertexInputLayout vertexInputLayout;
+    InputAssembly inputAssembly;
+    RasterizerState rasterizerState;
+    DepthStencilState depthStencilState;
+    ColorBlendState colorBlendState;
+    RenderTargetState renderTargetState;
+
     bool operator==(const GraphicsPipelineStateKey& other) const = default;
 };
 
@@ -31,6 +38,8 @@ public:
     virtual void Compile(const RHIShader& vertexShader,
                          const RHIShader& pixelShader,
                          RHIResourceLayout& resourceLayout) = 0;
+    virtual bool NeedsRecompile(const Key& newKey) = 0;
+    virtual void Cleanup(ResourceCleanup& resourceCleanup) = 0;
 
     Key key;
     u32 rootSignatureVersion = 0;
@@ -65,12 +74,25 @@ public:
 } // namespace vex
 
 // clang-format off
+
 VEX_MAKE_HASHABLE(vex::GraphicsPipelineStateKey, 
     VEX_HASH_COMBINE(seed, obj.vertexShader);
     VEX_HASH_COMBINE(seed, obj.pixelShader);
+    VEX_HASH_COMBINE(seed, obj.vertexInputLayout);
+    // Not used, PSO doesn't depend on this field.
+    //VEX_HASH_COMBINE(seed, obj.inputAssembly);
+    VEX_HASH_COMBINE(seed, obj.rasterizerState);
+    VEX_HASH_COMBINE(seed, obj.depthStencilState);
+    VEX_HASH_COMBINE(seed, obj.colorBlendState);
+    VEX_HASH_COMBINE(seed, obj.renderTargetState);
 );
 
 VEX_MAKE_HASHABLE(vex::ComputePipelineStateKey, 
     VEX_HASH_COMBINE(seed, obj.computeShader);
 );
+
+VEX_FORMATTABLE(vex::GraphicsPipelineStateKey, "GraphicsPipelineKey(\n\tVS: \"{}\"\n\tPS: \"{}\"\n\t",
+    obj.vertexShader, obj.pixelShader
+);
+
 // clang-format on

--- a/src/Vex/RHI/RHIPipelineState.h
+++ b/src/Vex/RHI/RHIPipelineState.h
@@ -79,8 +79,7 @@ VEX_MAKE_HASHABLE(vex::GraphicsPipelineStateKey,
     VEX_HASH_COMBINE(seed, obj.vertexShader);
     VEX_HASH_COMBINE(seed, obj.pixelShader);
     VEX_HASH_COMBINE(seed, obj.vertexInputLayout);
-    // Not used, PSO doesn't depend on this field.
-    //VEX_HASH_COMBINE(seed, obj.inputAssembly);
+    VEX_HASH_COMBINE(seed, obj.inputAssembly);
     VEX_HASH_COMBINE(seed, obj.rasterizerState);
     VEX_HASH_COMBINE(seed, obj.depthStencilState);
     VEX_HASH_COMBINE(seed, obj.colorBlendState);

--- a/src/Vex/RHI/RHIPipelineState.h
+++ b/src/Vex/RHI/RHIPipelineState.h
@@ -38,7 +38,6 @@ public:
     virtual void Compile(const RHIShader& vertexShader,
                          const RHIShader& pixelShader,
                          RHIResourceLayout& resourceLayout) = 0;
-    virtual bool NeedsRecompile(const Key& newKey) = 0;
     virtual void Cleanup(ResourceCleanup& resourceCleanup) = 0;
 
     Key key;

--- a/src/Vex/ShaderCompiler.cpp
+++ b/src/Vex/ShaderCompiler.cpp
@@ -79,8 +79,6 @@ ShaderCache::ShaderCache(RHI* rhi, bool enableShaderDebugging)
 
 ShaderCache::~ShaderCache() = default;
 
-thread_local CompilerUtil ShaderCache::GCompilerUtil;
-
 ComPtr<IDxcResult> ShaderCache::GetPreprocessedShader(const RHIShader& shader,
                                                       const ComPtr<IDxcBlobEncoding>& shaderBlobUTF8) const
 {
@@ -92,8 +90,11 @@ ComPtr<IDxcResult> ShaderCache::GetPreprocessedShader(const RHIShader& shader,
                          .Encoding = CP_UTF8 };
 
     ComPtr<IDxcResult> result;
-    if (HRESULT hr = GCompilerUtil.compiler
-                         ->Compile(&buffer, args.data(), static_cast<u32>(args.size()), nullptr, IID_PPV_ARGS(&result));
+    if (HRESULT hr = GetCompilerUtil().compiler->Compile(&buffer,
+                                                         args.data(),
+                                                         static_cast<u32>(args.size()),
+                                                         nullptr,
+                                                         IID_PPV_ARGS(&result));
         FAILED(hr))
     {
         return nullptr;
@@ -110,11 +111,17 @@ void ShaderCache::FillInAdditionalIncludeDirectories(std::vector<LPCWSTR>& args)
     }
 }
 
+CompilerUtil& ShaderCache::GetCompilerUtil()
+{
+    thread_local CompilerUtil GCompilerUtil;
+    return GCompilerUtil;
+}
+
 std::optional<std::size_t> ShaderCache::GetShaderHash(const RHIShader& shader) const
 {
     ComPtr<IDxcBlobEncoding> shaderBlobUTF8;
     u32 codePage = CP_UTF8;
-    if (HRESULT hr = GCompilerUtil.utils->LoadFile(shader.key.path.wstring().c_str(), &codePage, &shaderBlobUTF8);
+    if (HRESULT hr = GetCompilerUtil().utils->LoadFile(shader.key.path.wstring().c_str(), &codePage, &shaderBlobUTF8);
         FAILED(hr))
     {
         VEX_LOG(Error, "Unable to get shader hash, failed to load shader from filepath: {}", shader.key.path.string());
@@ -183,10 +190,10 @@ std::expected<void, std::string> ShaderCache::CompileShader(RHIShader& shader,
 #endif
 
     ComPtr<IDxcBlobEncoding> shaderBlob;
-    if (HRESULT hr = GCompilerUtil.utils->CreateBlobFromPinned(shaderFileStr.c_str(),
-                                                               shaderFileStr.size(),
-                                                               CP_UTF8,
-                                                               &shaderBlob);
+    if (HRESULT hr = GetCompilerUtil().utils->CreateBlobFromPinned(shaderFileStr.c_str(),
+                                                                   shaderFileStr.size(),
+                                                                   CP_UTF8,
+                                                                   &shaderBlob);
         FAILED(hr))
     {
         return std::unexpected("Failed to load shader from filesystem.");
@@ -217,7 +224,7 @@ std::expected<void, std::string> ShaderCache::CompileShader(RHIShader& shader,
 
     std::vector<DxcDefine> dxcDefines = ShaderCompiler_Internal::ConvertDefinesToDxcDefine(defines);
     ComPtr<IDxcCompilerArgs> compilerArgs;
-    if (HRESULT hr = GCompilerUtil.utils->BuildArguments(
+    if (HRESULT hr = GetCompilerUtil().utils->BuildArguments(
             shader.key.path.wstring().c_str(),
             StringToWString(shader.key.entryPoint).c_str(),
             ShaderCompiler_Internal::GetTargetFromShaderType(shader.key.type).c_str(),
@@ -233,11 +240,11 @@ std::expected<void, std::string> ShaderCache::CompileShader(RHIShader& shader,
     }
 
     ComPtr<IDxcResult> shaderCompilationResults;
-    HRESULT compilationHR = GCompilerUtil.compiler->Compile(&shaderSource,
-                                                            compilerArgs->GetArguments(),
-                                                            compilerArgs->GetCount(),
-                                                            GCompilerUtil.defaultIncludeHandler.operator->(),
-                                                            IID_PPV_ARGS(&shaderCompilationResults));
+    HRESULT compilationHR = GetCompilerUtil().compiler->Compile(&shaderSource,
+                                                                compilerArgs->GetArguments(),
+                                                                compilerArgs->GetCount(),
+                                                                GetCompilerUtil().defaultIncludeHandler.operator->(),
+                                                                IID_PPV_ARGS(&shaderCompilationResults));
 
     ComPtr<IDxcBlobUtf8> errors = nullptr;
     if (HRESULT hrError = shaderCompilationResults->GetOutput(DXC_OUT_ERRORS, IID_PPV_ARGS(&errors), nullptr);

--- a/src/Vex/ShaderCompiler.h
+++ b/src/Vex/ShaderCompiler.h
@@ -87,7 +87,7 @@ private:
     ComPtr<IDxcResult> GetPreprocessedShader(const RHIShader& shader, const ComPtr<IDxcBlobEncoding>& shaderBlob) const;
     void FillInAdditionalIncludeDirectories(std::vector<LPCWSTR>& args) const;
 
-    static thread_local CompilerUtil GCompilerUtil;
+    static CompilerUtil& GetCompilerUtil();
 
     RHI* rhi;
     // Determines if shaders should be compiled with debug symbols.

--- a/src/Vex/ShaderKey.h
+++ b/src/Vex/ShaderKey.h
@@ -40,15 +40,19 @@ struct ShaderKey
 } // namespace vex
 
 // clang-format off
+
+VEX_MAKE_HASHABLE(vex::ShaderDefine,
+    VEX_HASH_COMBINE(seed, obj.name);
+    VEX_HASH_COMBINE(seed, obj.value);  
+);
+
 VEX_MAKE_HASHABLE(vex::ShaderKey, 
     VEX_HASH_COMBINE(seed, obj.path);
     VEX_HASH_COMBINE(seed, obj.entryPoint);
     VEX_HASH_COMBINE_ENUM(seed, obj.type);
-    VEX_HASH_COMBINE_CONTAINER(seed, obj.defines,
-        VEX_HASH_COMBINE(seed, item.name);
-        VEX_HASH_COMBINE(seed, item.value);
-    );
+    VEX_HASH_COMBINE_CONTAINER(seed, obj.defines);
 );
+
 // clang-format on
 
 VEX_FORMATTABLE(vex::ShaderDefine, "ShaderDefine(\"{}\", \"{}\")", obj.name, obj.value);

--- a/src/Vex/Texture.h
+++ b/src/Vex/Texture.h
@@ -11,7 +11,7 @@
 namespace vex
 {
 
-enum class TextureType
+enum class TextureType : u8
 {
     Texture2D,
     TextureCube,
@@ -19,7 +19,7 @@ enum class TextureType
 };
 
 // Used internally for views (eg: a cubemap can either be interpreted as a 6 slice Texture2DArray or a TextureCube).
-enum class TextureViewType
+enum class TextureViewType : u8
 {
     Texture2D,
     Texture2DArray,
@@ -36,9 +36,20 @@ TextureViewType GetTextureViewType(const ResourceBinding& binding);
 TextureFormat GetTextureFormat(const ResourceBinding& binding);
 } // namespace TextureUtil
 
+// clang-format off
+
+BEGIN_VEX_ENUM_FLAGS(TextureClear, u8)
+    None = 0,
+    ClearColor = 1,
+    ClearDepth = 2,
+    ClearStencil = 4,
+END_VEX_ENUM_FLAGS();
+
+// clang-format on
+
 struct TextureClearValue
 {
-    bool enabled = false;
+    TextureClear::Flags flags = TextureClear::None;
     float color[4];
     float depth;
     u8 stencil;

--- a/src/Vulkan/VkCommandList.cpp
+++ b/src/Vulkan/VkCommandList.cpp
@@ -207,6 +207,11 @@ void VkCommandList::SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIReso
                                       nullptr);
 }
 
+void VkCommandList::SetInputAssembly(InputAssembly inputAssembly)
+{
+    VEX_NOT_YET_IMPLEMENTED();
+}
+
 // This only changes the access mask of the texture
 ::vk::ImageMemoryBarrier2 GetMemoryBarrierFrom(VkTexture& texture, RHITextureState::Flags flags)
 {
@@ -312,6 +317,11 @@ void VkCommandList::Transition(std::span<std::pair<RHITexture&, RHITextureState:
     {
         rhiTexture.SetCurrentState(flags);
     }
+}
+
+void VkCommandList::Draw(u32 vertexCount)
+{
+    commandBuffer->draw(vertexCount, 1, 0, 0);
 }
 
 void VkCommandList::Dispatch(const std::array<u32, 3>& groupCount)

--- a/src/Vulkan/VkCommandList.cpp
+++ b/src/Vulkan/VkCommandList.cpp
@@ -212,6 +212,13 @@ void VkCommandList::SetInputAssembly(InputAssembly inputAssembly)
     VEX_NOT_YET_IMPLEMENTED();
 }
 
+void VkCommandList::ClearTexture(RHITexture& rhiTexture,
+                                 const ResourceBinding& clearBinding,
+                                 const TextureClearValue& clearValue)
+{
+    VEX_NOT_YET_IMPLEMENTED();
+}
+
 // This only changes the access mask of the texture
 ::vk::ImageMemoryBarrier2 GetMemoryBarrierFrom(VkTexture& texture, RHITextureState::Flags flags)
 {

--- a/src/Vulkan/VkCommandList.h
+++ b/src/Vulkan/VkCommandList.h
@@ -35,9 +35,12 @@ public:
                                     std::span<RHIBufferBinding> buffers,
                                     RHIDescriptorPool& descriptorPool) override;
     virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout) override;
+    virtual void SetInputAssembly(InputAssembly inputAssembly) override;
 
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) override;
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) override;
+
+    virtual void Draw(u32 vertexCount) override;
 
     virtual void Dispatch(const std::array<u32, 3>& groupCount) override;
 

--- a/src/Vulkan/VkCommandList.h
+++ b/src/Vulkan/VkCommandList.h
@@ -36,6 +36,9 @@ public:
                                     RHIDescriptorPool& descriptorPool) override;
     virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout) override;
     virtual void SetInputAssembly(InputAssembly inputAssembly) override;
+    virtual void ClearTexture(RHITexture& rhiTexture,
+                              const ResourceBinding& clearBinding,
+                              const TextureClearValue& clearValue) override;
 
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) override;
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) override;

--- a/src/Vulkan/VkHeaders.h
+++ b/src/Vulkan/VkHeaders.h
@@ -11,4 +11,25 @@
 #endif
 
 #include <vulkan/vulkan.hpp>
-#undef None // We use None as an enum value which causes issues there.
+
+#if defined(__linux__)
+// Undefine problematic X11 macros on Linux
+#ifdef Always
+#undef Always
+#endif
+#ifdef None
+#undef None
+#endif
+#ifdef Success
+#undef Success
+#endif
+#ifdef Bool
+#undef Bool
+#endif
+#ifdef True
+#undef True
+#endif
+#ifdef False
+#undef False
+#endif
+#endif

--- a/src/Vulkan/VkPipelineState.cpp
+++ b/src/Vulkan/VkPipelineState.cpp
@@ -24,6 +24,18 @@ void VkGraphicsPipelineState::Compile(const RHIShader& vertexShader,
     VEX_NOT_YET_IMPLEMENTED();
 }
 
+bool VkGraphicsPipelineState::NeedsRecompile(const Key& newKey)
+{
+    // TODO: determine what is needed and what isn't, dynamic rendering should reduce how we compare this.
+    VEX_NOT_YET_IMPLEMENTED();
+    return false;
+}
+
+void VkGraphicsPipelineState::Cleanup(ResourceCleanup& resourceCleanup)
+{
+    VEX_NOT_YET_IMPLEMENTED();
+}
+
 VkComputePipelineState::VkComputePipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache)
     : RHIComputePipelineState(key)
     , device{ device }

--- a/src/Vulkan/VkPipelineState.cpp
+++ b/src/Vulkan/VkPipelineState.cpp
@@ -1,6 +1,6 @@
-#include "VkPipelineState.h"
 #include "Vex/RHI/RHIShader.h"
 #include "VkErrorHandler.h"
+#include "VkPipelineState.h"
 #include "VkResourceLayout.h"
 
 #include <Vex/Containers/ResourceCleanup.h>
@@ -22,13 +22,6 @@ void VkGraphicsPipelineState::Compile(const RHIShader& vertexShader,
                                       RHIResourceLayout& resourceLayout)
 {
     VEX_NOT_YET_IMPLEMENTED();
-}
-
-bool VkGraphicsPipelineState::NeedsRecompile(const Key& newKey)
-{
-    // TODO: determine what is needed and what isn't, dynamic rendering should reduce how we compare this.
-    VEX_NOT_YET_IMPLEMENTED();
-    return false;
 }
 
 void VkGraphicsPipelineState::Cleanup(ResourceCleanup& resourceCleanup)

--- a/src/Vulkan/VkPipelineState.h
+++ b/src/Vulkan/VkPipelineState.h
@@ -14,7 +14,6 @@ public:
     virtual void Compile(const RHIShader& vertexShader,
                          const RHIShader& pixelShader,
                          RHIResourceLayout& resourceLayout) override;
-    virtual bool NeedsRecompile(const Key& newKey) override;
     virtual void Cleanup(ResourceCleanup& resourceCleanup) override;
 };
 

--- a/src/Vulkan/VkPipelineState.h
+++ b/src/Vulkan/VkPipelineState.h
@@ -14,6 +14,8 @@ public:
     virtual void Compile(const RHIShader& vertexShader,
                          const RHIShader& pixelShader,
                          RHIResourceLayout& resourceLayout) override;
+    virtual bool NeedsRecompile(const Key& newKey) override;
+    virtual void Cleanup(ResourceCleanup& resourceCleanup) override;
 };
 
 class VkComputePipelineState : public RHIComputePipelineState


### PR DESCRIPTION
- This is the first part (1/N) of the Graphics Pipeline features.
- Added possibility to create and bind graphics pipelines (including all features from DX12 and Vulkan).
- Implemented the DX12-side of graphics PSO creation and draw calls
- Added a new Vex example showing off a hello triangle with the graphics pipeline.
- Added a draw function to the command context (ends up being a draw with 1 instance).
- Only SV_VertexId shaders work currently due to us not having VBs/IBs/Buffers.
- Cleaned up the draw interface by using intermediate structures for the draw information.

# Important:
This PR does NOT contain the finalized version of GraphicsPSO caching, the truth of the matter is that Vulkan's dynamic rendering changes what data we want to store directly inside the GraphicsPSOKey. Currently I store everything but future work is needed on this to get this working in a more flexible state (will be done in another PR later on).
Additionally there are many operations (eg: SetInputAssembly) that are being done EACH draw call, but could probably end up being done only once. Same goes for the way we set the PSO on each draw call, when in reality we could remember the previously set draw call and only call SetPSO on the command list if the new one differs from the previous one.