### PR TITLE
Buffers creation and usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ add_library(Vex STATIC
     "src/Vex/RHI/RHITexture.h"
     "src/Vex/Formats.cpp"
     "src/Vex/RHI/RHIBuffer.h"
+    "src/Vex/RHI/RHIBuffer.cpp"
     "src/Vex/Texture.h"
     "src/Vex/Texture.cpp"
     "src/Vex/Buffer.h"
@@ -160,6 +161,8 @@ add_library(Vex STATIC
     "src/Vex/ShaderCompiler.cpp"
     "src/Vex/Platform/Platform.h"
     "src/Vex/Formattable.h"
+    "src/Vex/ResourceBindingSet.cpp"
+    "src/Vex/ResourceBindingSet.h"
     "src/Vex/ShaderResourceContext.h"
     "src/Vex/ShaderResourceContext.cpp"
     "src/Vex/ShaderGen.h"
@@ -196,7 +199,7 @@ message(STATUS "Setting up Vex headers...")
 if(VEX_ENABLE_DX12)
     include(VexDX12)
     setup_dx12_backend(Vex)
-elseif(VEX_ENABLE_VULKAN)  
+elseif(VEX_ENABLE_VULKAN)
     include(VexVulkan)
     setup_vulkan_backend(Vex)
 endif()
@@ -236,7 +239,7 @@ endif()
 # Disable exceptions across the board.
 target_compile_options(Vex PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/EHs-c- /wd4530 /D_HAS_EXCEPTIONS=0>  # MSVC: disable exceptions, suppress warning for exception handler
-    $<$<CXX_COMPILER_ID:Clang>:-fno-exceptions>                     # Clang: disable exceptions  
+    $<$<CXX_COMPILER_ID:Clang>:-fno-exceptions>                     # Clang: disable exceptions
     $<$<CXX_COMPILER_ID:GNU>:-fno-exceptions>                       # GCC: disable exceptions
 )
 

--- a/cmake/VexDX12.cmake
+++ b/cmake/VexDX12.cmake
@@ -74,6 +74,8 @@ function(setup_dx12_backend TARGET)
         "src/DX12/DX12States.cpp"
         "src/DX12/DX12GraphicsPipeline.h"
         "src/DX12/DX12GraphicsPipeline.cpp"
+        "src/DX12/DX12Buffer.h"
+        "src/DX12/DX12Buffer.cpp"
     )
 
     # Add DX12 sources to target

--- a/cmake/VexVulkan.cmake
+++ b/cmake/VexVulkan.cmake
@@ -48,6 +48,8 @@ function(setup_vulkan_backend TARGET)
         "src/Vulkan/VkMemory.h"
         "src/Vulkan/VkDescriptorPool.h"
         "src/Vulkan/VkDescriptorPool.cpp"
+        "src/Vulkan/VkBuffer.h"
+        "src/Vulkan/VkBuffer.cpp"
     )
 
     # Add Vulkan sources to target

--- a/examples/hello_triangle/HelloTriangleApplication.h
+++ b/examples/hello_triangle/HelloTriangleApplication.h
@@ -20,4 +20,8 @@ protected:
 
 private:
     vex::Texture workingTexture;
+    vex::Texture finalOutputTexture;
+
+    vex::Buffer colorBuffer;
+    vex::Buffer commBuffer;
 };

--- a/examples/hello_triangle/HelloTriangleShader.cs.hlsl
+++ b/examples/hello_triangle/HelloTriangleShader.cs.hlsl
@@ -1,5 +1,8 @@
 VEX_GLOBAL_RESOURCE(RWTexture2D<float4>, OutputTexture);
 
+VEX_GLOBAL_RESOURCE(ByteAddressBuffer, ColorBuffer);
+VEX_GLOBAL_RESOURCE(RWByteAddressBuffer, CommBuffer);
+
 // Sourced from IQuilez SDF functions
 float dot2(float2 v)
 {
@@ -22,14 +25,17 @@ float sdf(float2 p)
 
     // Convert pixel coordinates to normalized space for opengl-based sdf function (-1 to 1)
     float2 uv = float2(dtid.xy) / max(width, height).xx * 2 - 1;
+
+    float4 color = ColorBuffer.Load<float4>(0);
+    CommBuffer.Store<float4>(0, float4(1,1,1,1) - color);
+
     uv.y += 0.25f;
     uv.y *= -1;
     uv /= 0.63f;
 
     if (sdf(uv) < 0)
     {
-        float3 color = float3(uv.x, uv.y, 1 - uv.x * uv.y);
-        OutputTexture[dtid.xy] = float4(color, 1.0f);
+        OutputTexture[dtid.xy] = float4(color.rgb, 1.0f);
     }
     else
     {

--- a/examples/hello_triangle/HelloTriangleShader2.cs.hlsl
+++ b/examples/hello_triangle/HelloTriangleShader2.cs.hlsl
@@ -1,4 +1,7 @@
 VEX_GLOBAL_RESOURCE(RWTexture2D<float4>, OutputTexture);
+VEX_GLOBAL_RESOURCE(Texture2D<float4>, SourceTexture);
+
+VEX_GLOBAL_RESOURCE(ByteAddressBuffer, CommBuffer);
 
 // Simple function to check if a point is inside a triangle
 bool IsInsideTriangle(float2 p, float2 v0, float2 v1, float2 v2)
@@ -34,6 +37,10 @@ bool IsInsideTriangle(float2 p, float2 v0, float2 v1, float2 v2)
     if (IsInsideTriangle(uv, v0, v1, v2) || IsInsideTriangle(uv - float2(1.15, 0), v0, v1, v2))
     {
         float3 color = float3(uv.x, uv.y, 1 - uv.x * uv.y);
-        OutputTexture[dtid.xy] += float4(color, 1.0f);
+        OutputTexture[dtid.xy] = CommBuffer.Load<float4>(0);
+    }
+    else
+    {
+        OutputTexture[dtid.xy] = SourceTexture.Load(uint3(dtid.xy, 0));
     }
 }

--- a/src/DX12/DX12Buffer.cpp
+++ b/src/DX12/DX12Buffer.cpp
@@ -1,0 +1,36 @@
+﻿#include "DX12Buffer.h"
+
+#include "Vex/Buffer.h"
+#include "Vex/Debug.h"
+
+namespace vex::dx12
+{
+
+DX12Buffer::DX12Buffer(ComPtr<DX12Device>& device, const BufferDescription& desc)
+    : RHIBuffer(desc)
+{
+}
+
+UniqueHandle<RHIBuffer> DX12Buffer::CreateStagingBuffer()
+{
+    VEX_NOT_YET_IMPLEMENTED();
+    return {};
+}
+
+std::span<u8> DX12Buffer::Map()
+{
+    VEX_NOT_YET_IMPLEMENTED();
+    return {};
+}
+
+void DX12Buffer::Unmap()
+{
+    VEX_NOT_YET_IMPLEMENTED();
+}
+
+void DX12Buffer::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
+{
+    VEX_NOT_YET_IMPLEMENTED();
+}
+
+} // namespace vex::dx12

--- a/src/DX12/DX12Buffer.h
+++ b/src/DX12/DX12Buffer.h
@@ -1,0 +1,26 @@
+﻿#pragma once
+
+#include "DX12Headers.h"
+
+#include <Vex/RHI/RHIBuffer.h>
+
+namespace vex
+{
+struct BufferDescription;
+}
+namespace vex::dx12
+{
+
+class DX12Buffer : public RHIBuffer
+{
+    virtual UniqueHandle<RHIBuffer> CreateStagingBuffer() override;
+
+public:
+    DX12Buffer(ComPtr<DX12Device>& device, const BufferDescription& desc);
+
+    virtual std::span<u8> Map() override;
+    virtual void Unmap() override;
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
+};
+
+} // namespace vex::dx12

--- a/src/DX12/DX12CommandList.h
+++ b/src/DX12/DX12CommandList.h
@@ -41,13 +41,16 @@ public:
                               const TextureClearValue& clearValue) override;
 
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) override;
+    virtual void Transition(RHIBuffer& buffer, RHIBufferState::Flags newState) override;
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) override;
+    virtual void Transition(std::span<std::pair<RHIBuffer&, RHIBufferState::Flags>> bufferNewStatePairs) override;
 
     virtual void Draw(u32 vertexCount) override;
 
     virtual void Dispatch(const std::array<u32, 3>& groupCount) override;
 
     virtual void Copy(RHITexture& src, RHITexture& dst) override;
+    virtual void Copy(RHIBuffer& src, RHIBuffer& dst) override;
 
     virtual CommandQueueType GetType() const override;
 

--- a/src/DX12/DX12RHI.cpp
+++ b/src/DX12/DX12RHI.cpp
@@ -1,5 +1,7 @@
 #include "DX12RHI.h"
 
+#include "DX12Buffer.h"
+
 #include <Vex/Logger.h>
 #include <Vex/PlatformWindow.h>
 
@@ -156,6 +158,11 @@ UniqueHandle<RHIResourceLayout> DX12RHI::CreateResourceLayout(RHIDescriptorPool&
 UniqueHandle<RHITexture> DX12RHI::CreateTexture(const TextureDescription& description)
 {
     return MakeUnique<DX12Texture>(device, description);
+}
+
+UniqueHandle<RHIBuffer> DX12RHI::CreateBuffer(const BufferDescription& description)
+{
+    return MakeUnique<DX12Buffer>(device, description);
 }
 
 UniqueHandle<RHIDescriptorPool> DX12RHI::CreateDescriptorPool()

--- a/src/DX12/DX12RHI.h
+++ b/src/DX12/DX12RHI.h
@@ -36,6 +36,7 @@ public:
     virtual UniqueHandle<RHIResourceLayout> CreateResourceLayout(RHIDescriptorPool& descriptorPool) override;
 
     virtual UniqueHandle<RHITexture> CreateTexture(const TextureDescription& description) override;
+    virtual UniqueHandle<RHIBuffer> CreateBuffer(const BufferDescription& description) override;
 
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() override;
 

--- a/src/DX12/DX12ResourceLayout.cpp
+++ b/src/DX12/DX12ResourceLayout.cpp
@@ -5,9 +5,9 @@
 #include <utility>
 
 #include <Vex/Logger.h>
-#include <Vex/ResourceBindingSet.h>
 #include <Vex/PhysicalDevice.h>
 #include <Vex/Platform/Windows/HResult.h>
+#include <Vex/ResourceBindingSet.h>
 
 #include <DX12/DX12TextureSampler.h>
 #include <DX12/HRChecker.h>
@@ -24,7 +24,7 @@ DX12ResourceLayout::~DX12ResourceLayout() = default;
 
 u32 DX12ResourceLayout::GetMaxLocalConstantSize() const
 {
-    return reinterpret_cast<DX12FeatureChecker*>(GPhysicalDevice->featureChecker.get())->GetMaxRootSignatureDWORDSize()
+    return reinterpret_cast<DX12FeatureChecker*>(GPhysicalDevice->featureChecker.get())->GetMaxRootSignatureDWORDSize();
 }
 
 ComPtr<ID3D12RootSignature>& DX12ResourceLayout::GetRootSignature()
@@ -50,15 +50,6 @@ void DX12ResourceLayout::CompileRootSignature()
     rootParameters.push_back(std::move(rootConstants));
 
     // TODO: consider descriptor tables?
-
-    for (const GlobalConstant& constant : globalConstants | std::views::values)
-    {
-        CD3DX12_ROOT_PARAMETER globalConstantParameter;
-        globalConstantParameter.InitAsConstantBufferView(rootSignatureDWORDCount);
-        rootParameters.push_back(std::move(globalConstantParameter));
-
-        rootSignatureDWORDCount += 2;
-    }
 
     std::vector<D3D12_STATIC_SAMPLER_DESC> dxSamplers =
         GraphicsPipeline::GetDX12StaticSamplersFromTextureSamplers(samplers);

--- a/src/DX12/DX12ResourceLayout.h
+++ b/src/DX12/DX12ResourceLayout.h
@@ -15,7 +15,6 @@ public:
     DX12ResourceLayout(ComPtr<DX12Device>& device);
     virtual ~DX12ResourceLayout() override;
 
-    virtual bool ValidateGlobalConstant(const GlobalConstant& globalConstant) const override;
     virtual u32 GetMaxLocalConstantSize() const override;
 
     ComPtr<ID3D12RootSignature>& GetRootSignature();

--- a/src/Vex.h
+++ b/src/Vex.h
@@ -5,6 +5,8 @@
 #include <Vex/DrawHelpers.h>
 #include <Vex/FeatureChecker.h>
 #include <Vex/GfxBackend.h>
+#include <Vex/Logger.h>
+#include <Vex/ResourceBindingSet.h>
 #include <Vex/GraphicsPipeline.h>
 #include <Vex/TextureSampler.h>
 

--- a/src/Vex/Bindings.h
+++ b/src/Vex/Bindings.h
@@ -14,13 +14,15 @@ struct ConstantBinding
 {
     template <typename T>
     ConstantBinding(const T& data)
-        : data{ &data }
+        : data{ static_cast<const void*>(&data) }
         , size{ sizeof(T) }
     {
     }
 
-    void* data;
+    const void* data;
     u32 size;
+
+    static std::vector<u8> ConcatConstantBindings(std::span<const ConstantBinding> constantBindings, u32 maxBufferSize);
 };
 
 // clang-format off
@@ -58,11 +60,11 @@ struct ResourceBinding
     // 0 means to use every slice.
     u32 sliceCount = 0;
 
-    bool IsBuffer() const
+    [[nodiscard]] bool IsBuffer() const
     {
         return buffer.handle != GInvalidBufferHandle;
     }
-    bool IsTexture() const
+    [[nodiscard]] bool IsTexture() const
     {
         return texture.handle != GInvalidTextureHandle;
     }

--- a/src/Vex/Buffer.h
+++ b/src/Vex/Buffer.h
@@ -1,23 +1,39 @@
 #pragma once
 
-#include <limits>
 #include <string>
 
+#include <Vex/EnumFlags.h>
 #include <Vex/Handle.h>
 #include <Vex/Types.h>
 
 namespace vex
 {
 
+enum class BufferUsage : u8
+{
+    StagingBuffer,
+    VertexBuffer,
+    IndexBuffer,
+    GenericBuffer
+};
+
+// clang-format off
+
+BEGIN_VEX_ENUM_FLAGS(BufferMemoryAccess, u8)
+    CPURead,
+    CPUWrite,
+    GPURead,
+    GPUWrite
+END_VEX_ENUM_FLAGS();
+
+// clang-format on
+
 struct BufferDescription
 {
     std::string name;
-    u32 size;
-};
-
-struct BufferView
-{
-    // TODO: implement buffers
+    u32 byteSize;
+    BufferUsage usage;
+    BufferMemoryAccess::Flags memoryAccess;
 };
 
 // Strongly defined type represents a buffer.
@@ -30,8 +46,8 @@ static constexpr BufferHandle GInvalidBufferHandle;
 
 struct Buffer final
 {
-    const BufferHandle handle;
-    const BufferDescription description;
+    BufferHandle handle;
+    BufferDescription description;
 };
 
 } // namespace vex

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -1,22 +1,21 @@
 #pragma once
 
 #include <optional>
-#include <span>
 
-#include <Vex/GraphicsPipeline.h>
 #include <Vex/RHI/RHIFwd.h>
 #include <Vex/RHI/RHIPipelineState.h>
 #include <Vex/ShaderKey.h>
 #include <Vex/Types.h>
-#include <Vex/UniqueHandle.h>
 
 namespace vex
 {
 
+class ResourceBindingSet;
 class GfxBackend;
 struct ConstantBinding;
 struct ResourceBinding;
 struct Texture;
+struct Buffer;
 struct TextureClearValue;
 struct DrawDescription;
 struct DrawResources;
@@ -51,13 +50,10 @@ public:
     {
     }
 
-    void Dispatch(const ShaderKey& shader,
-                  std::span<const ConstantBinding> constants,
-                  std::span<const ResourceBinding> reads,
-                  std::span<const ResourceBinding> readWrites,
-                  std::array<u32, 3> groupCount);
+    void Dispatch(const ShaderKey& shader, const ResourceBindingSet& resourceBindingSet, std::array<u32, 3> groupCount);
 
     void Copy(const Texture& source, const Texture& destination);
+    void Copy(const Buffer& source, const Buffer& destination);
 
 private:
     GfxBackend* backend;

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -182,6 +182,28 @@ Texture GfxBackend::CreateTexture(TextureDescription description, ResourceLifeti
                     .description = std::move(description) };
 }
 
+Buffer GfxBackend::CreateBuffer(BufferDescription description, ResourceLifetime lifetime)
+{
+    if (lifetime == ResourceLifetime::Dynamic)
+    {
+        // TODO: handle dynamic resources, includes specifying that the resource when bound should use dynamic bindless
+        // indices and self-cleanup of the RHITexture should occur after the current frame ends.
+        VEX_NOT_YET_IMPLEMENTED();
+    }
+
+    auto rhiBuffer = rhi->CreateBuffer(description);
+    return Buffer{ .handle = bufferRegistry.AllocateElement(std::move(rhiBuffer)),
+                   .description = std::move(description) };
+}
+
+void GfxBackend::UpdateData(const Buffer& buffer, std::span<const u8> data)
+{
+    VEX_ASSERT(data.size() <= buffer.description.byteSize, "Buffer data exceded buffer size");
+
+    RHIBuffer& rhiBuffer = GetRHIBuffer(buffer.handle);
+    rhiBuffer.GetMappedMemory()->SetData(data);
+}
+
 void GfxBackend::DestroyTexture(const Texture& texture)
 {
     resourceCleanup.CleanupResource(std::move(textureRegistry[texture.handle]));

--- a/src/Vex/RHI/RHI.h
+++ b/src/Vex/RHI/RHI.h
@@ -13,6 +13,7 @@
 
 namespace vex
 {
+struct BufferDescription;
 
 struct ShaderDefine;
 struct PhysicalDevice;
@@ -39,6 +40,7 @@ struct RenderHardwareInterface
     virtual UniqueHandle<RHIResourceLayout> CreateResourceLayout(RHIDescriptorPool& descriptorPool) = 0;
 
     virtual UniqueHandle<RHITexture> CreateTexture(const TextureDescription& description) = 0;
+    virtual UniqueHandle<RHIBuffer> CreateBuffer(const BufferDescription& description) = 0;
 
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() = 0;
 

--- a/src/Vex/RHI/RHIBuffer.cpp
+++ b/src/Vex/RHI/RHIBuffer.cpp
@@ -1,0 +1,66 @@
+﻿#include "RHIBuffer.h"
+
+#include <Vex/Debug.h>
+
+namespace vex
+{
+
+struct DirectBufferMemory : RHIMappedBufferMemory
+{
+    explicit DirectBufferMemory(RHIBuffer& target)
+        : buffer{ target }
+    {
+        data = buffer.Map();
+    }
+
+    virtual void SetData(std::span<const u8> inData) override
+    {
+        VEX_ASSERT(data.size() >= inData.size());
+        std::ranges::copy(inData, data.begin());
+    }
+
+    ~DirectBufferMemory() override
+    {
+        buffer.Unmap();
+    }
+
+    std::span<u8> data;
+    RHIBuffer& buffer;
+};
+
+struct StagedBufferMemory : DirectBufferMemory
+{
+    explicit StagedBufferMemory(RHIBuffer& stagingBuffer, RHIBuffer& realBuffer)
+        : DirectBufferMemory(stagingBuffer)
+        , realBuffer{ realBuffer }
+    {
+    }
+
+    ~StagedBufferMemory() override
+    {
+        realBuffer.SetNeedsStagingBufferCopy(true);
+    }
+
+    RHIBuffer& realBuffer;
+};
+
+bool DoesBufferNeedStagingBuffer(const BufferDescription& desc)
+{
+    return (desc.memoryAccess & BufferMemoryAccess::GPURead | desc.memoryAccess & BufferMemoryAccess::GPUWrite) &&
+           !(desc.memoryAccess & BufferMemoryAccess::CPURead | desc.memoryAccess & BufferMemoryAccess::CPUWrite);
+}
+
+UniqueHandle<RHIMappedBufferMemory> RHIBuffer::GetMappedMemory()
+{
+    if (DoesBufferNeedStagingBuffer(desc))
+    {
+        if (!stagingBuffer)
+        {
+            stagingBuffer = CreateStagingBuffer();
+        }
+        return MakeUnique<StagedBufferMemory>(*stagingBuffer, *this);
+    }
+    return MakeUnique<DirectBufferMemory>(*this);
+}
+
+} // namespace vex

--- a/src/Vex/RHI/RHIBuffer.h
+++ b/src/Vex/RHI/RHIBuffer.h
@@ -1,12 +1,93 @@
 #pragma once
 
+#include <span>
+
+#include <Vex/Buffer.h>
+#include <Vex/Types.h>
+#include <Vex/UniqueHandle.h>
+
 namespace vex
 {
+class RHIDescriptorPool;
+
+// clang-format off
+
+BEGIN_VEX_ENUM_FLAGS(RHIBufferState, u8)
+    Common,
+    CopySource,
+    CopyDest,
+    ConstantBuffer,
+    StructuredBuffer,
+    IndexBuffer,
+    VertexBuffer,
+    ShaderRead,
+END_VEX_ENUM_FLAGS();
+
+// clang-format on
+
+// RAII structure to wrap Map and Unmap operations on a buffer
+class RHIMappedBufferMemory
+{
+public:
+    virtual ~RHIMappedBufferMemory() = default;
+    virtual void SetData(std::span<const u8> data) = 0;
+};
 
 class RHIBuffer
 {
 public:
-    ~RHIBuffer() = default;
+    // RAII safe version to access buffer memory
+    UniqueHandle<RHIMappedBufferMemory> GetMappedMemory();
+
+    // Raw direct access to buffer memory
+    virtual std::span<u8> Map() = 0;
+    virtual void Unmap() = 0;
+
+    [[nodiscard]] bool NeedsStagingBufferCopy() const noexcept
+    {
+        return needsStagingBufferCopy;
+    };
+    void SetNeedsStagingBufferCopy(const bool value)
+    {
+        needsStagingBufferCopy = value;
+    }
+
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) = 0;
+
+    void SetCurrentState(const RHIBufferState::Flags flags)
+    {
+        currentState = flags;
+    }
+
+    [[nodiscard]] RHIBufferState::Flags GetCurrentState() const noexcept
+    {
+        return currentState;
+    }
+
+    [[nodiscard]] const BufferDescription& GetDescription() const noexcept
+    {
+        return desc;
+    };
+
+    virtual RHIBuffer* GetStagingBuffer()
+    {
+        return stagingBuffer.get();
+    };
+    virtual ~RHIBuffer() = default;
+
+protected:
+    BufferDescription desc;
+
+    explicit RHIBuffer(const BufferDescription& desc)
+        : desc{ desc }
+    {
+    }
+
+    UniqueHandle<RHIBuffer> stagingBuffer;
+    RHIBufferState::Flags currentState = RHIBufferState::Common;
+    bool needsStagingBufferCopy = false;
+
+    virtual UniqueHandle<RHIBuffer> CreateStagingBuffer() = 0;
 };
 
 } // namespace vex

--- a/src/Vex/RHI/RHICommandList.h
+++ b/src/Vex/RHI/RHICommandList.h
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include <Vex/RHI/RHI.h>
+#include <Vex/RHI/RHIBuffer.h>
 #include <Vex/RHI/RHITexture.h>
 #include <Vex/Types.h>
 
@@ -50,19 +51,17 @@ public:
                               const TextureClearValue& clearValue) = 0;
 
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) = 0;
+    virtual void Transition(RHIBuffer& texture, RHIBufferState::Flags newState) = 0;
     // Ideal for batching multiple resource transitions together.
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) = 0;
+    virtual void Transition(std::span<std::pair<RHIBuffer&, RHIBufferState::Flags>> bufferNewStatePairs) = 0;
 
     virtual void Draw(u32 vertexCount) = 0;
 
     virtual void Dispatch(const std::array<u32, 3>& groupCount) = 0;
 
     virtual void Copy(RHITexture& src, RHITexture& dst) = 0;
-
-    // TODO: implement (not using VEX_NOT_YET_IMPLEMENTED since we're in a .h), will be done in a Buffer-specific PR.
-    // virtual void Copy(RHIBuffer& src, RHIBuffer& dst)
-    //{
-    //}
+    virtual void Copy(RHIBuffer& src, RHIBuffer& dst) = 0;
 
     virtual CommandQueueType GetType() const = 0;
 };

--- a/src/Vex/RHI/RHIResourceLayout.cpp
+++ b/src/Vex/RHI/RHIResourceLayout.cpp
@@ -1,5 +1,7 @@
 #include "RHIResourceLayout.h"
 
+#include <Vex/Logger.h>
+
 namespace vex
 {
 

--- a/src/Vex/RHI/RHIResourceLayout.cpp
+++ b/src/Vex/RHI/RHIResourceLayout.cpp
@@ -1,9 +1,5 @@
 #include "RHIResourceLayout.h"
 
-#include <ranges>
-
-#include <Vex/Logger.h>
-
 namespace vex
 {
 
@@ -26,79 +22,6 @@ void RHIResourceLayout::SetSamplers(std::span<TextureSampler> newSamplers)
 std::span<const TextureSampler> RHIResourceLayout::GetStaticSamplers() const
 {
     return { samplers.begin(), samplers.end() };
-}
-
-ScopedGlobalConstantHandle RHIResourceLayout::RegisterScopedGlobalConstant(GlobalConstant globalConstant)
-{
-    std::string globalContantName = globalConstant.name;
-    if (globalConstants.contains(globalContantName))
-    {
-        VEX_LOG(Fatal, "Cannot register already registered global constant.");
-    }
-
-    if (!ValidateGlobalConstant(globalConstant))
-    {
-        VEX_LOG(Fatal, "Unable to validate global constant...");
-    }
-
-    globalConstants[globalContantName] = std::move(globalConstant);
-    isDirty = true;
-
-    return ScopedGlobalConstantHandle(*this, std::move(globalContantName));
-}
-GlobalConstantHandle RHIResourceLayout::RegisterGlobalConstant(GlobalConstant globalConstant)
-{
-    std::string globalContantName = globalConstant.name;
-    if (globalConstants.contains(globalContantName))
-    {
-        VEX_LOG(Fatal, "Cannot register already registered global constant.");
-    }
-
-    if (!ValidateGlobalConstant(globalConstant))
-    {
-        VEX_LOG(Fatal, "Unable to validate global constant...");
-    }
-
-    globalConstants[globalContantName] = std::move(globalConstant);
-    isDirty = true;
-
-    return GlobalConstantHandle{ std::move(globalContantName) };
-}
-
-void RHIResourceLayout::UnregisterGlobalConstant(GlobalConstantHandle globalConstantHandle)
-{
-    if (!globalConstants.contains(globalConstantHandle.name))
-    {
-        VEX_LOG(Fatal, "Cannot unregister non-registered global resource handle.");
-        return;
-    }
-
-    globalConstants.erase(globalConstantHandle.name);
-    isDirty = true;
-}
-
-bool RHIResourceLayout::ValidateGlobalConstant(const GlobalConstant& globalConstant) const
-{
-    // Make sure no other global constant is using the same slot/space pair.
-    for (const auto& constant : globalConstants | std::views::values)
-    {
-        if (constant.slot == globalConstant.slot && constant.space == globalConstant.space)
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-ScopedGlobalConstantHandle::ScopedGlobalConstantHandle(RHIResourceLayout& globalLayout, std::string name)
-    : name{ std::move(name) }
-    , globalLayout{ globalLayout }
-{
-}
-
-ScopedGlobalConstantHandle::~ScopedGlobalConstantHandle()
-{
-    globalLayout.UnregisterGlobalConstant({ std::move(name) });
 }
 
 } // namespace vex

--- a/src/Vex/RHI/RHIResourceLayout.h
+++ b/src/Vex/RHI/RHIResourceLayout.h
@@ -2,7 +2,6 @@
 
 #include <span>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <Vex/TextureSampler.h>
@@ -10,16 +9,8 @@
 
 namespace vex
 {
-
-// Global constant buffer of memory.
-// Should be updated infrequently (eg: once per frame).
-struct GlobalConstant
-{
-    std::string name;
-    u32 size;
-    u32 slot;
-    u32 space;
-};
+class RHIBuffer;
+class ResourceBindingSet;
 
 class RHIResourceLayout;
 
@@ -49,13 +40,6 @@ public:
     void SetSamplers(std::span<TextureSampler> newSamplers);
     std::span<const TextureSampler> GetStaticSamplers() const;
 
-    ScopedGlobalConstantHandle RegisterScopedGlobalConstant(GlobalConstant globalConstant);
-    GlobalConstantHandle RegisterGlobalConstant(GlobalConstant globalConstant);
-    void UnregisterGlobalConstant(GlobalConstantHandle globalConstantHandle);
-
-    // Used to verify that the global constant would not make us bust the max size, slot or space imposed by our
-    // graphics API.
-    virtual bool ValidateGlobalConstant(const GlobalConstant& globalConstant) const;
     // Returns the max size of local constants that the graphics API supports.
     virtual u32 GetMaxLocalConstantSize() const = 0;
 
@@ -65,8 +49,6 @@ public:
 
 protected:
     bool isDirty = true;
-    std::unordered_map<std::string, GlobalConstant> globalConstants;
-
     std::vector<TextureSampler> samplers;
 };
 

--- a/src/Vex/Resource.h
+++ b/src/Vex/Resource.h
@@ -16,7 +16,7 @@ BEGIN_VEX_ENUM_FLAGS(ResourceUsage, u8)
     DepthStencil    = 1 << 3, // DSV in DX12, Depth/Stencil Attachment in Vulkan
 END_VEX_ENUM_FLAGS();
 
- //clang-format on
+//clang-format on
 
 enum class ResourceLifetime : u8
 {

--- a/src/Vex/ResourceBindingSet.cpp
+++ b/src/Vex/ResourceBindingSet.cpp
@@ -1,0 +1,40 @@
+﻿#include "ResourceBindingSet.h"
+
+#include "GfxBackend.h"
+#include "RHI/RHITexture.h"
+
+namespace vex
+{
+
+void ResourceBindingSet::ValidateBindings() const
+{
+    ResourceBinding::ValidateResourceBindings(reads, ResourceUsage::Read);
+    ResourceBinding::ValidateResourceBindings(writes, ResourceUsage::UnorderedAccess);
+}
+
+void ResourceBindingSet::CollectRHIResources(GfxBackend& backend,
+                                             std::span<const ResourceBinding> resources,
+                                             std::vector<RHITextureBinding>& textureBindings,
+                                             std::vector<RHIBufferBinding>& bufferBindings,
+                                             ResourceUsage::Type usage)
+{
+    textureBindings.reserve(textureBindings.size() + resources.size());
+    bufferBindings.reserve(bufferBindings.size() + resources.size());
+
+    for (const auto& binding : resources)
+    {
+        if (binding.IsTexture())
+        {
+            auto& texture = backend.GetRHITexture(binding.texture.handle);
+            textureBindings.emplace_back(binding, usage, &texture);
+        }
+
+        if (binding.IsBuffer())
+        {
+            auto& buffer = backend.GetRHIBuffer(binding.buffer.handle);
+            bufferBindings.emplace_back(binding, usage, &buffer);
+        }
+    }
+}
+
+} // namespace vex

--- a/src/Vex/ResourceBindingSet.h
+++ b/src/Vex/ResourceBindingSet.h
@@ -1,0 +1,34 @@
+﻿#pragma once
+
+#include <vector>
+
+#include <Vex/Bindings.h>
+#include <Vex/RHI/RHIBindings.h>
+
+namespace vex
+{
+class GfxBackend;
+
+// This represents the different resources that will be used in the specific draw call/dispatch
+class ResourceBindingSet
+{
+public:
+    static void CollectRHIResources(GfxBackend& backend,
+                                    std::span<const ResourceBinding> resources,
+                                    std::vector<RHITextureBinding>& textureBindings,
+                                    std::vector<RHIBufferBinding>& bufferBindings,
+                                    ResourceUsage::Type usage);
+
+    std::vector<ResourceBinding> reads;
+    std::vector<ResourceBinding> writes;
+    std::vector<ConstantBinding> constants;
+
+    std::span<const ConstantBinding> GetConstantBindings() const noexcept
+    {
+        return constants;
+    }
+
+    void ValidateBindings() const;
+};
+
+} // namespace vex

--- a/src/Vex/ShaderCompiler.cpp
+++ b/src/Vex/ShaderCompiler.cpp
@@ -233,9 +233,10 @@ std::expected<void, std::string> ShaderCompiler::CompileShader(RHIShader& shader
     shaderSource.Encoding = DXC_CP_ACP; // Assume BOM says UTF8 or UTF16 or this is ANSI text.
 
     std::vector<LPCWSTR> args;
-    std::vector<ShaderDefine> defines = shader.key.defines;
 
-    rhi->ModifyShaderCompilerEnvironment(args, defines);
+    std::vector<ShaderDefine> shaderDefines = shader.key.defines;
+
+    rhi->ModifyShaderCompilerEnvironment(args, shaderDefines);
 
     if (compilerSettings.enableShaderDebugging)
     {
@@ -255,7 +256,7 @@ std::expected<void, std::string> ShaderCompiler::CompileShader(RHIShader& shader
 
     FillInAdditionalIncludeDirectories(args);
 
-    std::vector<DxcDefine> dxcDefines = ShaderCompiler_Internal::ConvertDefinesToDxcDefine(defines);
+    std::vector<DxcDefine> defines = ShaderCompiler_Internal::ConvertDefinesToDxcDefine(shaderDefines);
     ComPtr<IDxcCompilerArgs> compilerArgs;
     if (HRESULT hr = GetCompilerUtil().utils->BuildArguments(
             shader.key.path.wstring().c_str(),
@@ -263,8 +264,8 @@ std::expected<void, std::string> ShaderCompiler::CompileShader(RHIShader& shader
             ShaderCompiler_Internal::GetTargetFromShaderType(shader.key.type).c_str(),
             args.data(),
             static_cast<u32>(args.size()),
-            dxcDefines.data(),
-            static_cast<u32>(dxcDefines.size()),
+            defines.data(),
+            static_cast<u32>(defines.size()),
             &compilerArgs);
         FAILED(hr))
     {

--- a/src/Vex/ShaderGen.h
+++ b/src/Vex/ShaderGen.h
@@ -24,72 +24,90 @@ constexpr const char* ShaderGenBindingMacros = R"(
 
 #elif defined(VEX_VULKAN)
 
-// Heaps can overlap in vulkan! This means we can just declare every heap with every type, 
+// Heaps can overlap in vulkan! This means we can just declare every heap with every type,
 // in order to have a singular templated function to access any bindless resource.
 
-#define VEX_DECLARE_DESCRIPTOR_HEAP(type, primType, name, REG) \
+#define VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, primType, name, REG) \
     type<primType> name##_##primType[] : register(REG);
 
-#define VEX_DECLARE_DESCRIPTOR_HEAP_FOR_EACH_PRIMITIVE(type, name, REG) \
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, float4, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, float3, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, float2, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, float, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, uint4, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, uint3, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, uint2, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, uint, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, int4, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, int3, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, int2, name, REG)\
-    VEX_DECLARE_DESCRIPTOR_HEAP(type, int, name, REG)
+#define VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE(type, name, REG) \
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, float4, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, float3, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, float2, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, float, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, uint4, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, uint3, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, uint2, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, uint, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, int4, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, int3, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, int2, name, REG)\
+    VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE(type, int, name, REG)
+
+#define VEX_DECLARE_DESCRIPTOR_HEAP(type, name, REG) \
+    type name[] : register(REG);
 
 template<typename T>
 T VexGetBindlessResource(uint index);
 
-#define VEX_RESOURCE_BINDLESS_DECLARATION(type, primType, heapName) \
+#define VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, primType, heapName) \
     template<>\
     type<primType> VexGetBindlessResource(uint index)\
     {\
         return heapName##_##primType[index];\
     }
 
-#define VEX_RESOURCE_BINDLESS_DECLARATION_FOR_EACH_PRIMITIVE(type, heapName) \
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, float4, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, float3, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, float2, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, float, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, uint4, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, uint3, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, uint2, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, uint, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, int4, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, int3, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, int2, heapName)\
-    VEX_RESOURCE_BINDLESS_DECLARATION(type, int, heapName)
+#define VEX_RESOURCE_BINDLESS_DECLARATION(type, heapName) \
+    template<>\
+    type VexGetBindlessResource(uint index)\
+    {\
+        return heapName[index];\
+    }
+
+#define VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE(type, heapName) \
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, float4, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, float3, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, float2, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, float, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, uint4, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, uint3, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, uint2, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, uint, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, int4, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, int3, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, int2, heapName)\
+    VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE(type, int, heapName)
 
 // -----------------------------------------------------------------------------------------------
 
-VEX_DECLARE_DESCRIPTOR_HEAP_FOR_EACH_PRIMITIVE(RWTexture2D, RWTexture2DDescriptorHeap, u3)
-VEX_RESOURCE_BINDLESS_DECLARATION_FOR_EACH_PRIMITIVE(RWTexture2D, RWTexture2DDescriptorHeap)
+VEX_DECLARE_DESCRIPTOR_HEAP(ByteAddressBuffer, ByteAddressBufferDescriptorHeap, t1)
+VEX_RESOURCE_BINDLESS_DECLARATION(ByteAddressBuffer, ByteAddressBufferDescriptorHeap)
 
-// etc... for other heap types
+VEX_DECLARE_DESCRIPTOR_HEAP(RWByteAddressBuffer, RWByteAddressBufferDescriptorHeap, u1)
+VEX_RESOURCE_BINDLESS_DECLARATION(RWByteAddressBuffer, RWByteAddressBufferDescriptorHeap)
+
+VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE(Texture2D, Texture2DDescriptorHeap, t2)
+VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE(Texture2D, Texture2DDescriptorHeap)
+
+VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE(RWTexture2D, RWTexture2DDescriptorHeap, u3)
+VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE(RWTexture2D, RWTexture2DDescriptorHeap)
 
 // -----------------------------------------------------------------------------------------------
 
-#undef VEX_DECLARE_DESCRIPTOR_HEAP
-#undef VEX_DECLARE_DESCRIPTOR_HEAP_FOR_EACH_PRIMITIVE
-#undef VEX_RESOURCE_BINDLESS_DECLARATION_FOR_EACH_PRIMITIVE
-#undef VEX_RESOURCE_BINDLESS_DECLARATION
+#undef VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE
+#undef VEX_DECLARE_DESCRIPTOR_HEAP_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE
+#undef VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE_FOR_EACH_PRIMITIVE
+#undef VEX_RESOURCE_BINDLESS_DECLARATION_SPECIFIC_TYPE
 
 // -----------------------------------------------------------------------------------------------
 
 #define VEX_GLOBAL_RESOURCE(type, name) static type name = VexGetBindlessResource<type>(zzzZZZ___GeneratedConstantsCB.name##_bindlessIndex)
 
-#endif
+#else
 
 // TODO(https://trello.com/c/bIVo8EP9): Users could also eventually get the bindless index (eg for storing a StructuredBuffer of materials, each material having bindless indices towards its textures such as albedo.)
 // In this case they should use this macro to get the resource, this macro should contain additional checks to avoid using invalid handles.
 #define VEX_BINDLESS_RESOURCE(type, name, index) 0
 
+#endif
 )";

--- a/src/Vulkan/VkBuffer.cpp
+++ b/src/Vulkan/VkBuffer.cpp
@@ -1,0 +1,185 @@
+﻿#include "VkBuffer.h"
+
+#include <Vex/Buffer.h>
+
+#include "VkCommandQueue.h"
+#include "VkErrorHandler.h"
+#include "VkGPUContext.h"
+#include "VkMemory.h"
+
+namespace vex::vk
+{
+::vk::BufferUsageFlags GetVkBufferUsageFromDesc(const BufferDescription& desc)
+{
+    using enum ::vk::BufferUsageFlagBits;
+    switch (desc.usage)
+    {
+    case BufferUsage::StagingBuffer:
+        return eTransferSrc;
+    case BufferUsage::GenericBuffer:
+        return eStorageBuffer;
+    case BufferUsage::IndexBuffer:
+        return eIndexBuffer;
+    case BufferUsage::VertexBuffer:
+        return eVertexBuffer;
+    default:
+        VEX_LOG(Fatal, "RHIBuffer::Usage not supported by VulkanRHI")
+        break;
+    }
+    std::unreachable();
+}
+
+::vk::MemoryPropertyFlags GetMemoryPropsFromDesc(const BufferDescription& desc)
+{
+    using enum ::vk::MemoryPropertyFlagBits;
+
+    bool GPUWrite = desc.memoryAccess & BufferMemoryAccess::GPUWrite;
+    bool GPURead = desc.memoryAccess & BufferMemoryAccess::GPURead;
+    bool CPUWrite = desc.memoryAccess & BufferMemoryAccess::CPUWrite;
+    bool CPURead = desc.memoryAccess & BufferMemoryAccess::CPURead;
+
+    if (!CPUWrite && !CPURead)
+    {
+        if (GPUWrite || GPURead)
+        {
+            return eDeviceLocal;
+        }
+    }
+    else
+    {
+        if (GPUWrite || GPURead)
+        {
+            return eHostCoherent | eHostVisible;
+        }
+    }
+
+    std::unreachable();
+}
+
+VkBuffer::VkBuffer(VkGPUContext& ctx, const BufferDescription& desc)
+    : RHIBuffer{ desc }
+    , ctx{ ctx }
+{
+    auto bufferUsage = GetVkBufferUsageFromDesc(desc);
+    auto memoryProps = GetMemoryPropsFromDesc(desc);
+
+    if (memoryProps & ::vk::MemoryPropertyFlagBits::eDeviceLocal)
+    {
+        // Needs to get its data from somewhere. Will therefore always need a transfer dest usage
+        bufferUsage |= ::vk::BufferUsageFlagBits::eTransferDst;
+    }
+
+    buffer = VEX_VK_CHECK <<=
+        ctx.device.createBufferUnique({ .size = desc.byteSize,
+                                        .usage = bufferUsage,
+                                        .sharingMode = ::vk::SharingMode::eExclusive,
+                                        .queueFamilyIndexCount = 1,
+                                        .pQueueFamilyIndices = &ctx.graphicsPresentQueue.family });
+
+    const ::vk::MemoryRequirements reqs = ctx.device.getBufferMemoryRequirements(*buffer);
+
+    memory = VEX_VK_CHECK <<= ctx.device.allocateMemoryUnique(
+        { .allocationSize = reqs.size,
+          .memoryTypeIndex = GetBestMemoryType(ctx.physDevice, reqs.memoryTypeBits, memoryProps) });
+
+    VEX_VK_CHECK << ctx.device.bindBufferMemory(*buffer, *memory, 0);
+}
+
+BindlessHandle VkBuffer::GetOrCreateBindlessIndex(VkGPUContext& ctx, VkDescriptorPool& descriptorPool)
+{
+    if (bufferHandle)
+    {
+        return *bufferHandle;
+    }
+
+    const BindlessHandle handle = descriptorPool.AllocateStaticDescriptor(*this);
+
+    descriptorPool.UpdateDescriptor(
+        ctx,
+        handle,
+        ::vk::DescriptorBufferInfo{ .buffer = *buffer, .offset = 0, .range = desc.byteSize });
+
+    bufferHandle = handle;
+
+    return handle;
+}
+
+void VkBuffer::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
+{
+    if (bufferHandle && *bufferHandle != GInvalidBindlessHandle)
+    {
+        reinterpret_cast<VkDescriptorPool&>(descriptorPool).FreeStaticDescriptor(*bufferHandle);
+    }
+    bufferHandle.reset();
+}
+
+::vk::Buffer& VkBuffer::GetBuffer()
+{
+    return *buffer;
+}
+
+UniqueHandle<RHIBuffer> VkBuffer::CreateStagingBuffer()
+{
+    return MakeUnique<VkBuffer>(ctx,
+                                BufferDescription{
+                                    .name = desc.name + "_StagingBuffer",
+                                    .byteSize = desc.byteSize,
+                                    .usage = BufferUsage::StagingBuffer,
+                                    .memoryAccess = BufferMemoryAccess::CPUWrite | BufferMemoryAccess::GPURead,
+                                });
+}
+
+std::span<u8> VkBuffer::Map()
+{
+    void* ptr = VEX_VK_CHECK <<= ctx.device.mapMemory(*memory, 0, desc.byteSize);
+    return { static_cast<u8*>(ptr), desc.byteSize };
+}
+
+void VkBuffer::Unmap()
+{
+    ctx.device.unmapMemory(*memory);
+}
+
+} // namespace vex::vk
+
+::vk::AccessFlags2 vex::BufferUtil::GetAccessFlagsFromBufferState(RHIBufferState::Flags flags)
+{
+    using enum ::vk::AccessFlagBits2;
+    ::vk::AccessFlags2 accessFlags;
+    if (flags & RHIBufferState::ConstantBuffer)
+    {
+        accessFlags |= eUniformRead;
+    }
+
+    if (flags & RHIBufferState::StructuredBuffer)
+    {
+        accessFlags |= eShaderWrite | eShaderRead;
+    }
+
+    if (flags & RHIBufferState::Common)
+    {
+        accessFlags |= eNone;
+    }
+
+    if (flags & RHIBufferState::CopyDest)
+    {
+        accessFlags |= eTransferWrite;
+    }
+
+    if (flags & RHIBufferState::CopySource)
+    {
+        accessFlags |= eTransferRead;
+    }
+
+    if (flags & RHIBufferState::IndexBuffer)
+    {
+        accessFlags |= eIndexRead;
+    }
+
+    if (flags & RHIBufferState::VertexBuffer)
+    {
+        accessFlags |= eVertexAttributeRead;
+    }
+
+    return accessFlags;
+}

--- a/src/Vulkan/VkBuffer.h
+++ b/src/Vulkan/VkBuffer.h
@@ -1,0 +1,52 @@
+﻿#pragma once
+
+#include "VkDescriptorPool.h"
+#include "VkHeaders.h"
+
+#include <Vex/RHI/RHIBuffer.h>
+#include <Vex/Types.h>
+
+#include <span>
+
+namespace vex
+{
+struct BufferDescription;
+namespace BufferUtil
+{
+::vk::AccessFlags2 GetAccessFlagsFromBufferState(RHIBufferState::Flags flags);
+}
+} // namespace vex
+
+namespace vex::vk
+{
+struct VkStagingBuffer;
+struct VkGPUContext;
+class VkBuffer;
+struct VkDirectBufferMemory;
+
+class VkBuffer : public RHIBuffer
+{
+public:
+    VkBuffer(VkGPUContext& ctx, const BufferDescription& desc);
+
+    BindlessHandle GetOrCreateBindlessIndex(VkGPUContext& ctx, VkDescriptorPool& descriptorPool);
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
+    ::vk::Buffer& GetBuffer();
+
+    virtual std::span<u8> Map() override;
+    virtual void Unmap() override;
+
+private:
+    virtual UniqueHandle<RHIBuffer> CreateStagingBuffer() override;
+
+    ::vk::UniqueBuffer buffer;
+    ::vk::UniqueDeviceMemory memory;
+    VkGPUContext& ctx;
+
+    std::optional<BindlessHandle> bufferHandle;
+
+    friend struct VkStagedBufferMemory;
+    friend struct VkDirectBufferMemory;
+};
+
+} // namespace vex::vk

--- a/src/Vulkan/VkCommandList.h
+++ b/src/Vulkan/VkCommandList.h
@@ -41,13 +41,16 @@ public:
                               const TextureClearValue& clearValue) override;
 
     virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) override;
+    virtual void Transition(RHIBuffer& texture, RHIBufferState::Flags newState) override;
     virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) override;
+    virtual void Transition(std::span<std::pair<RHIBuffer&, RHIBufferState::Flags>> bufferNewStatePairs) override;
 
     virtual void Draw(u32 vertexCount) override;
 
     virtual void Dispatch(const std::array<u32, 3>& groupCount) override;
 
     virtual void Copy(RHITexture& src, RHITexture& dst) override;
+    virtual void Copy(RHIBuffer& src, RHIBuffer& dst) override;
 
     virtual CommandQueueType GetType() const override;
 

--- a/src/Vulkan/VkDescriptorPool.h
+++ b/src/Vulkan/VkDescriptorPool.h
@@ -32,7 +32,7 @@ public:
     VkDescriptorPool(::vk::Device device);
     virtual ~VkDescriptorPool() override;
 
-    BindlessHandle AllocateStaticDescriptor(const RHITexture& texture);
+    BindlessHandle AllocateStaticDescriptor(const RHITexture& texture, bool writeAccess);
     BindlessHandle AllocateStaticDescriptor(const RHIBuffer& buffer);
     void FreeStaticDescriptor(BindlessHandle handle);
 
@@ -43,6 +43,7 @@ public:
     bool IsValid(BindlessHandle handle);
 
     void UpdateDescriptor(VkGPUContext& ctx, BindlessHandle targetDescriptor, ::vk::DescriptorImageInfo createInfo);
+    void UpdateDescriptor(VkGPUContext& ctx, BindlessHandle targetDescriptor, ::vk::DescriptorBufferInfo createInfo);
 
 private:
     static constexpr std::array DescriptorTypes{

--- a/src/Vulkan/VkRHI.cpp
+++ b/src/Vulkan/VkRHI.cpp
@@ -9,6 +9,7 @@
 #include <Vex/RHI/RHIFence.h>
 
 #include "Synchro/VkFence.h"
+#include "VkBuffer.h"
 #include "VkCommandPool.h"
 #include "VkCommandQueue.h"
 #include "VkDebug.h"
@@ -301,6 +302,10 @@ UniqueHandle<RHIResourceLayout> VkRHI::CreateResourceLayout(RHIDescriptorPool& d
 UniqueHandle<RHITexture> VkRHI::CreateTexture(const TextureDescription& description)
 {
     return MakeUnique<VkImageTexture>(GetGPUContext(), TextureDescription(description));
+}
+UniqueHandle<RHIBuffer> VkRHI::CreateBuffer(const BufferDescription& description)
+{
+    return MakeUnique<VkBuffer>(GetGPUContext(), description);
 }
 
 UniqueHandle<RHIDescriptorPool> VkRHI::CreateDescriptorPool()

--- a/src/Vulkan/VkRHI.h
+++ b/src/Vulkan/VkRHI.h
@@ -2,14 +2,16 @@
 
 #include <Vex/RHI/RHI.h>
 
+#include "Vex/RHI/RHIBuffer.h"
 #include "VkCommandQueue.h"
 #include "VkGPUContext.h"
 #include "VkHeaders.h"
 
 namespace vex
 {
+struct BufferDescription;
 struct PlatformWindowHandle;
-}
+} // namespace vex
 
 namespace vex::vk
 {
@@ -36,6 +38,7 @@ public:
     virtual UniqueHandle<RHIResourceLayout> CreateResourceLayout(RHIDescriptorPool& descriptorPool) override;
 
     virtual UniqueHandle<RHITexture> CreateTexture(const TextureDescription& description) override;
+    virtual UniqueHandle<RHIBuffer> CreateBuffer(const BufferDescription& description) override;
 
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() override;
 

--- a/src/Vulkan/VkResourceLayout.cpp
+++ b/src/Vulkan/VkResourceLayout.cpp
@@ -1,7 +1,10 @@
 #include "VkResourceLayout.h"
 
+#include <Vex/ResourceBindingSet.h>
 #include <Vex/Debug.h>
 #include <Vex/PhysicalDevice.h>
+
+#include <numeric>
 
 #include "VkDescriptorPool.h"
 #include "VkErrorHandler.h"
@@ -29,21 +32,10 @@ VkResourceLayout::VkResourceLayout(::vk::Device device, const VkDescriptorPool& 
     version++;
 }
 
-bool VkResourceLayout::ValidateGlobalConstant(const GlobalConstant& globalConstant) const
-{
-    if (!RHIResourceLayout::ValidateGlobalConstant(globalConstant))
-    {
-        return false;
-    }
-
-    return true;
-}
 u32 VkResourceLayout::GetMaxLocalConstantSize() const
 {
     const u32 maxBytes =
         reinterpret_cast<VkFeatureChecker*>(GPhysicalDevice->featureChecker.get())->GetMaxPushConstantSize();
-
-    // TODO: Consider global constant in the available size
     return std::max<u32>(0, maxBytes);
 }
 } // namespace vex::vk

--- a/src/Vulkan/VkResourceLayout.h
+++ b/src/Vulkan/VkResourceLayout.h
@@ -13,7 +13,6 @@ class VkResourceLayout : public RHIResourceLayout
 {
 public:
     VkResourceLayout(::vk::Device device, const VkDescriptorPool& descriptorPool);
-    virtual bool ValidateGlobalConstant(const GlobalConstant& globalConstant) const override;
     virtual u32 GetMaxLocalConstantSize() const override;
 
     ::vk::UniquePipelineLayout pipelineLayout;

--- a/src/Vulkan/VkTexture.cpp
+++ b/src/Vulkan/VkTexture.cpp
@@ -109,7 +109,8 @@ BindlessHandle VkTexture::GetOrCreateBindlessView(VkGPUContext& ctx,
                                                 } };
 
     ::vk::UniqueImageView imageView = VEX_VK_CHECK <<= ctx.device.createImageViewUnique(viewCreate);
-    const BindlessHandle handle = descriptorPool.AllocateStaticDescriptor(*this);
+    const BindlessHandle handle =
+        descriptorPool.AllocateStaticDescriptor(*this, view.usage == ResourceUsage::UnorderedAccess);
 
     descriptorPool.UpdateDescriptor(
         ctx,

--- a/src/Vulkan/VkTexture.h
+++ b/src/Vulkan/VkTexture.h
@@ -15,6 +15,7 @@ struct VkTextureViewDesc
 {
     TextureViewType viewType = TextureViewType::Texture2D;
     TextureFormat format = TextureFormat::UNKNOWN;
+    ResourceUsage::Flags usage = ResourceUsage::None;
 
     u32 mipBias = 0;
     u32 mipCount = 1;
@@ -30,6 +31,7 @@ struct VkTextureViewDesc
 VEX_MAKE_HASHABLE(vex::vk::VkTextureViewDesc,
     VEX_HASH_COMBINE(seed, obj.viewType);
     VEX_HASH_COMBINE(seed, obj.format);
+    VEX_HASH_COMBINE(seed, obj.usage);
     VEX_HASH_COMBINE(seed, obj.mipBias);
     VEX_HASH_COMBINE(seed, obj.mipCount);
     VEX_HASH_COMBINE(seed, obj.startSlice);


### PR DESCRIPTION
### This PR implements:

- Readonly buffers (ByteAddressBuffer)
- ReadWrite buffers (RWByteAddressBuffer)
- Accessible from the CPU and GPU or GPU only
- If a buffer is GPU only uploading data to it will use a staging buffer otherwise it uses mapped memory directly
- Small fixes on vulkan side for readonly textures
 
### HelloTriangle changes

I decided to change the hello world app to use buffers as an example

### Caveats

1. Currently to support a fully bindless architecture we are constrained to using RWByteAddressBuffer and ByteAddressBuffer which are both (in vulkan at least) the same descriptor type. This means its currently not possible to bind ConstantBuffers to the shaders. Not exactly sure the impacts of that on perf. This seemed to be incompatible with bindless arch from what I recall

2. I couldn't find a good way to access the buffers of a specific type using the existing macro. One of the issue was the same as with the textures. I would need a partial specialization for any T which we found not being possible. Also the way to write to the buffer would have been another macro which might have been painful. We should discuss the user facing API for that since now only the BAB is provided by the macro and users need to Load<T> and Store<T> for their own type. We could create a custom generated type for that maybe?


I tried to share the most I could for DX and VK. lmk if you see more that could be shared