### PR TITLE
Improved CommandContext state caching

### DIFF
--- a/src/DX12/DX12CommandList.cpp
+++ b/src/DX12/DX12CommandList.cpp
@@ -373,10 +373,9 @@ void DX12CommandList::Transition(std::span<std::pair<RHITexture&, RHITextureStat
         DX12Texture& dxTexture = reinterpret_cast<DX12Texture&>(texture);
         D3D12_RESOURCE_BARRIER resourceBarrier =
             CD3DX12_RESOURCE_BARRIER::Transition(dxTexture.GetRawTexture(), currentDX12State, newDX12State);
+        transitionBarriers.push_back(std::move(resourceBarrier));
 
         texture.SetCurrentState(newState);
-
-        transitionBarriers.push_back(std::move(resourceBarrier));
     }
 
     if (!transitionBarriers.empty())

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -5,6 +5,7 @@
 
 #include <Vex/GraphicsPipeline.h>
 #include <Vex/RHI/RHIFwd.h>
+#include <Vex/RHI/RHIPipelineState.h>
 #include <Vex/ShaderKey.h>
 #include <Vex/Types.h>
 #include <Vex/UniqueHandle.h>
@@ -61,6 +62,13 @@ public:
 private:
     GfxBackend* backend;
     RHICommandList* cmdList;
+
+    // Used to avoid resetting the same state multiple times which can be costly on certain hardware.
+    // In general draws and dispatches are recommended to be grouped by PSO, so this caching can be very efficient
+    // versus binding everything each time.
+    std::optional<GraphicsPipelineStateKey> cachedGraphicsPSOKey = std::nullopt;
+    std::optional<ComputePipelineStateKey> cachedComputePSOKey = std::nullopt;
+    std::optional<InputAssembly> cachedInputAssembly = std::nullopt;
 };
 
 } // namespace vex


### PR DESCRIPTION
- The Graphics, Compute PSO keys are now cached, allowing for the CommandContext to not have to fetch the PSO if it was already bound.
- Added caching for the input assembly since it generally changes very rarely.
- Added logic in VkCommandList.cpp to not call any transitions if the list of transitions is empty. 