### PR TITLE
Changed command list submission to be batched as per vendor recommendations

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -37,16 +37,20 @@ jobs:
           # Remove unsupported compilers from windows/linux
           - os: windows-latest
             c_compiler: gcc
+            cpp_compiler: g++
           - os: ubuntu-latest
             c_compiler: cl
+            cpp_compiler: cl
           # Remove DirectX-only configurations from Linux (not supported)
           - os: ubuntu-latest
             graphics_api: directx12
           # Reduce the number of different jobs by limiting the directx-only / vulkan only builds to release targets
           - build_type: Debug
             c_compiler: gcc
+            cpp_compiler: g++
           - build_type: Debug
             c_compiler: cl
+            c_ppcompiler: cl
 
     name: ${{ matrix.os }} ${{ matrix.c_compiler }} ${{ matrix.build_type }} ${{ matrix.graphics_api }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -37,20 +37,16 @@ jobs:
           # Remove unsupported compilers from windows/linux
           - os: windows-latest
             c_compiler: gcc
-            cpp_compiler: g++
           - os: ubuntu-latest
             c_compiler: cl
-            cpp_compiler: cl
           # Remove DirectX-only configurations from Linux (not supported)
           - os: ubuntu-latest
             graphics_api: directx12
           # Reduce the number of different jobs by limiting the directx-only / vulkan only builds to release targets
           - build_type: Debug
             c_compiler: gcc
-            cpp_compiler: g++
           - build_type: Debug
             c_compiler: cl
-            c_ppcompiler: cl
 
     name: ${{ matrix.os }} ${{ matrix.c_compiler }} ${{ matrix.build_type }} ${{ matrix.graphics_api }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -154,19 +154,29 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+    - name: Setup MSVC environment
+      if: matrix.os == 'windows-latest' && matrix.c_compiler == 'cl'
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+
+    - name: Install Ninja
+      if: matrix.os == 'windows-latest'
+      run: |
+        choco install ninja
+
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -G Ninja
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-        ${{ matrix.os != 'windows-latest' && format('-DCMAKE_BUILD_TYPE={0}', matrix.build_type) || '' }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DVEX_BUILD_EXAMPLES=ON
         ${{ matrix.graphics_api == 'directx12' && '-DVEX_GRAPHICS_BACKEND=DX12' || '' }}
         ${{ matrix.graphics_api == 'vulkan' && '-DVEX_GRAPHICS_BACKEND=VULKAN' || '' }}
         -S ${{ github.workspace }}
+
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -163,6 +163,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -G Ninja
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         ${{ matrix.os != 'windows-latest' && format('-DCMAKE_BUILD_TYPE={0}', matrix.build_type) || '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,6 @@ set(VEX_ENABLE_VULKAN OFF)
 
 if(VEX_SELECTED_BACKEND STREQUAL "DX12")
     set(VEX_ENABLE_DX12 ON)
-    add_compile_definitions(NOMINMAX)
 elseif(VEX_SELECTED_BACKEND STREQUAL "VULKAN")
     set(VEX_ENABLE_VULKAN ON)
 else()
@@ -224,14 +223,21 @@ target_compile_definitions(Vex PUBLIC VEX_DX12=$<BOOL:${VEX_ENABLE_DX12}> VEX_VU
 
 if(WIN32)
     # Avoid windows polluting the code with macros.
-    target_compile_definitions(Vex PUBLIC NOMINMAX WIN32_MEAN_AND_LEAN)
+    target_compile_definitions(Vex PUBLIC NOMINMAX WIN32_LEAN_AND_MEAN)
+endif()
+
+# Remove MSVC's default exception handling flags
+if(MSVC)
+    string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REPLACE "/EHs" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REPLACE "/EHc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 # Disable exceptions across the board.
 target_compile_options(Vex PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/EHs-c->           # MSVC: disable exceptions
-    $<$<CXX_COMPILER_ID:Clang>:-fno-exceptions>   # Clang: disable exceptions  
-    $<$<CXX_COMPILER_ID:GNU>:-fno-exceptions>     # GCC: disable exceptions
+    $<$<CXX_COMPILER_ID:MSVC>:/EHs-c- /D_HAS_EXCEPTIONS=0 /EHs-c- /D_HAS_EXCEPTIONS=0 /wd4530>  # MSVC: disable exceptions
+    $<$<CXX_COMPILER_ID:Clang>:-fno-exceptions>             # Clang: disable exceptions  
+    $<$<CXX_COMPILER_ID:GNU>:-fno-exceptions>               # GCC: disable exceptions
 )
 
 # =========================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,9 +235,9 @@ endif()
 
 # Disable exceptions across the board.
 target_compile_options(Vex PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/EHs-c- /D_HAS_EXCEPTIONS=0 /EHs-c- /D_HAS_EXCEPTIONS=0 /wd4530>  # MSVC: disable exceptions
-    $<$<CXX_COMPILER_ID:Clang>:-fno-exceptions>             # Clang: disable exceptions  
-    $<$<CXX_COMPILER_ID:GNU>:-fno-exceptions>               # GCC: disable exceptions
+    $<$<CXX_COMPILER_ID:MSVC>:/EHs-c- /wd4530 /D_HAS_EXCEPTIONS=0>  # MSVC: disable exceptions, suppress warning for exception handler
+    $<$<CXX_COMPILER_ID:Clang>:-fno-exceptions>                     # Clang: disable exceptions  
+    $<$<CXX_COMPILER_ID:GNU>:-fno-exceptions>                       # GCC: disable exceptions
 )
 
 # =========================================

--- a/src/DX12/DX12RHI.h
+++ b/src/DX12/DX12RHI.h
@@ -40,6 +40,7 @@ public:
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() override;
 
     virtual void ExecuteCommandList(RHICommandList& commandList) override;
+    virtual void ExecuteCommandLists(std::span<RHICommandList*> commandLists) override;
 
     virtual UniqueHandle<RHIFence> CreateFence(u32 numFenceIndices) override;
     virtual void SignalFence(CommandQueueType queueType, RHIFence& fence, u32 fenceIndex) override;

--- a/src/DX12/DX12SwapChain.cpp
+++ b/src/DX12/DX12SwapChain.cpp
@@ -90,7 +90,7 @@ UniqueHandle<RHITexture> DX12SwapChain::CreateBackBuffer(u8 backBufferIndex)
 
 u8 DX12SwapChain::GetBackBufferCount(FrameBuffering frameBuffering)
 {
-    return std::max<u8>(2, std::to_underlying(frameBuffering));
+    return std::min(2, std::to_underlying(frameBuffering));
 }
 
 } // namespace vex::dx12

--- a/src/DX12/DX12SwapChain.cpp
+++ b/src/DX12/DX12SwapChain.cpp
@@ -90,7 +90,7 @@ UniqueHandle<RHITexture> DX12SwapChain::CreateBackBuffer(u8 backBufferIndex)
 
 u8 DX12SwapChain::GetBackBufferCount(FrameBuffering frameBuffering)
 {
-    return std::min(2, std::to_underlying(frameBuffering));
+    return std::max<u8>(2, std::to_underlying(frameBuffering));
 }
 
 } // namespace vex::dx12

--- a/src/Vex/FrameResource.h
+++ b/src/Vex/FrameResource.h
@@ -12,10 +12,10 @@ namespace vex
 
 // Determines how many frames should be in flight at once.
 // More frames in flight means less GPU starvation, but also more input latency.
+// Single buffering is not supported due to the APIs Vex supports not allowing for swapchains of less than 2
+// backbuffers.
 enum class FrameBuffering : u8
 {
-    // One frame in flight at once
-    Single = 1,
     // Two frames in flight at once
     Double = 2,
     // Three frames in flight at once

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -91,6 +91,8 @@ private:
     RHIBuffer& GetRHIBuffer(BufferHandle bufferHandle);
 
     void CreateBackBuffers();
+    // Executes all currently queued up command lists.
+    void FlushCommandListQueue();
 
     // Index of the current frame, possible values depends on buffering:
     //  {0} if single buffering
@@ -124,6 +126,9 @@ private:
     // Converts from the Handle to the actual underlying RHI resource.
     FreeList<UniqueHandle<RHITexture>, TextureHandle> textureRegistry;
     FreeList<UniqueHandle<RHIBuffer>, BufferHandle> bufferRegistry;
+
+    // We submit our command lists in batch at the end of the frame, to reduce driver overhead.
+    std::vector<RHICommandList*> queuedCommandLists;
 
     inline static constexpr u32 DefaultRegistrySize = 1024;
 

--- a/src/Vex/RHI/RHI.h
+++ b/src/Vex/RHI/RHI.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include <Vex/CommandQueueType.h>
@@ -42,6 +43,7 @@ struct RenderHardwareInterface
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() = 0;
 
     virtual void ExecuteCommandList(RHICommandList& commandList) = 0;
+    virtual void ExecuteCommandLists(std::span<RHICommandList*> commandLists) = 0;
 
     virtual UniqueHandle<RHIFence> CreateFence(u32 numFenceIndices) = 0;
     virtual void SignalFence(CommandQueueType queueType, RHIFence& fence, u32 fenceIndex) = 0;

--- a/src/Vulkan/VkRHI.cpp
+++ b/src/Vulkan/VkRHI.cpp
@@ -339,6 +339,16 @@ void VkRHI::ExecuteCommandList(RHICommandList& commandList)
     VEX_VK_CHECK << cmdQueue.queue.submit2KHR(submitInfo);
 }
 
+void VkRHI::ExecuteCommandLists(std::span<RHICommandList*> commandLists)
+{
+    // TODO(https://trello.com/c/J4WjMkVk): Improve this, the other function has semaphores and stuff, it seemed a bit
+    // complicated, so I just call it once per CommandList for now (which is obviously not optimal).
+    for (RHICommandList* cmdList : commandLists)
+    {
+        ExecuteCommandList(*cmdList);
+    }
+}
+
 UniqueHandle<RHIFence> VkRHI::CreateFence(u32 numFenceIndices)
 {
     return MakeUnique<VkFence>(numFenceIndices, *device);

--- a/src/Vulkan/VkRHI.h
+++ b/src/Vulkan/VkRHI.h
@@ -40,6 +40,7 @@ public:
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() override;
 
     virtual void ExecuteCommandList(RHICommandList& commandList) override;
+    virtual void ExecuteCommandLists(std::span<RHICommandList*> commandLists) override;
 
     virtual UniqueHandle<RHIFence> CreateFence(u32 numFenceIndices) override;
     virtual void SignalFence(CommandQueueType queueType, RHIFence& fence, u32 fenceIndex) override;


### PR DESCRIPTION
Vendors recommend that command lists be submitted in one batch, this is for multiple reasons:
- Reduces driver overhead.
- Allows the driver to potentially concatenate the command lists together (if synchronization allows) which can lead to better performance.

Other changes:
- Also made DX12 RHI crash if single buffering is used, since it technically does not support it (instead of the previous way of handling things which was to still allocate two backbuffers and then try to lie that its supported).
- The Vulkan side of things was a bit more complicated than I expected, so I just kept the current logic (making sure no crashes occur). Added a trello to improve this: https://trello.com/c/J4WjMkVk

This PR also fixes a few issues with the GitHub actions yml (for example, clang-windows was actually not using clang at all).