### PR TITLE
Samplers (Vex and DX12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ add_library(Vex STATIC
     "src/Vex/ShaderResourceContext.h"
     "src/Vex/ShaderResourceContext.cpp"
     "src/Vex/ShaderGen.h"
+    "src/Vex/TextureSampler.h"
     "src/Vex/GraphicsPipeline.h"
     "src/Vex/DrawHelpers.h"
 )

--- a/cmake/VexDX12.cmake
+++ b/cmake/VexDX12.cmake
@@ -68,6 +68,8 @@ function(setup_dx12_backend TARGET)
         "src/DX12/DX12DescriptorHeap.h"
         "src/DX12/DX12DescriptorPool.h"
         "src/DX12/DX12DescriptorPool.cpp"
+        "src/DX12/DX12TextureSampler.h"
+        "src/DX12/DX12TextureSampler.cpp"
         "src/DX12/DX12States.h"
         "src/DX12/DX12States.cpp"
         "src/DX12/DX12GraphicsPipeline.h"

--- a/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
+++ b/examples/example_hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
@@ -48,6 +48,9 @@ HelloTriangleGraphicsApplication::HelloTriangleGraphicsApplication()
         .enableGPUDebugLayer = !VEX_SHIPPING,
         .enableGPUBasedValidation = !VEX_SHIPPING });
 
+    std::vector<vex::TextureSampler> samplers{ vex::TextureSampler{ .name = "MySampler" } };
+    graphics->SetSamplers(samplers);
+
     workingTexture =
         graphics->CreateTexture({ .name = "Working Texture",
                                   .type = vex::TextureType::Texture2D,

--- a/src/DX12/DX12ResourceLayout.cpp
+++ b/src/DX12/DX12ResourceLayout.cpp
@@ -4,9 +4,9 @@
 #include <utility>
 
 #include <Vex/Logger.h>
-
 #include <Vex/Platform/Windows/HResult.h>
 
+#include <DX12/DX12TextureSampler.h>
 #include <DX12/HRChecker.h>
 
 namespace vex::dx12
@@ -77,13 +77,14 @@ void DX12ResourceLayout::CompileRootSignature()
         rootSignatureDWORDCount += 2;
     }
 
-    // TODO: add static samplers!
+    std::vector<D3D12_STATIC_SAMPLER_DESC> dxSamplers =
+        GraphicsPipeline::GetDX12StaticSamplersFromTextureSamplers(samplers);
 
     CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc =
         CD3DX12_ROOT_SIGNATURE_DESC(static_cast<u32>(rootParameters.size()),
                                     rootParameters.data(),
-                                    0,
-                                    nullptr,
+                                    dxSamplers.size(),
+                                    dxSamplers.data(),
                                     D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
                                         D3D12_ROOT_SIGNATURE_FLAG_CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED 
             // Evaluate the usefulness of bindless samplers, static samplers seem to be easier to map to how Vulkan works.

--- a/src/DX12/DX12TextureSampler.cpp
+++ b/src/DX12/DX12TextureSampler.cpp
@@ -1,0 +1,105 @@
+#include "DX12TextureSampler.h"
+
+#include <Vex/Logger.h>
+#include <Vex/TextureSampler.h>
+
+#include <DX12/DX12GraphicsPipeline.h>
+
+namespace vex::dx12
+{
+
+namespace GraphicsPipeline
+{
+
+D3D12_TEXTURE_ADDRESS_MODE GetDX12TextureAddressModeFromAddressMode(AddressMode addressMode)
+{
+    return static_cast<D3D12_TEXTURE_ADDRESS_MODE>(std::to_underlying(addressMode) + 1);
+}
+
+D3D12_STATIC_BORDER_COLOR GetDX12StaticBorderColorFromBorderColor(BorderColor borderColor)
+{
+    switch (borderColor)
+    {
+    case BorderColor::TransparentBlackFloat:
+    case BorderColor::TransparentBlackInt:
+        return D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+    case BorderColor::OpaqueBlackFloat:
+        return D3D12_STATIC_BORDER_COLOR_OPAQUE_BLACK;
+    case BorderColor::OpaqueBlackInt:
+        return D3D12_STATIC_BORDER_COLOR_OPAQUE_BLACK_UINT;
+    case BorderColor::OpaqueWhiteFloat:
+        return D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE;
+    case BorderColor::OpaqueWhiteInt:
+        return D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE_UINT;
+    default:
+        VEX_LOG(Fatal, "Invalid border color passed to DX12 border color conversion function.");
+    }
+    std::unreachable();
+}
+
+D3D12_FILTER GetDX12FilterFromFilterMode(FilterMode minFilter,
+                                         FilterMode magFilter,
+                                         FilterMode mipFilter,
+                                         bool useComparison)
+{
+    // D3D12 filter is a combination of min, mag, and mip filters
+    if (minFilter == FilterMode::Anisotropic || magFilter == FilterMode::Anisotropic)
+    {
+        return useComparison ? D3D12_FILTER_COMPARISON_ANISOTROPIC : D3D12_FILTER_ANISOTROPIC;
+    }
+
+    // Build the filter value based on min, mag, and mip filter combinations
+    UINT filterValue = 0;
+
+    // Min filter (bits 4-5)
+    if (minFilter == FilterMode::Linear)
+        filterValue |= 0x10;
+
+    // Mag filter (bits 2-3)
+    if (magFilter == FilterMode::Linear)
+        filterValue |= 0x04;
+
+    // Mip filter (bits 0-1)
+    if (mipFilter == FilterMode::Linear)
+        filterValue |= 0x01;
+
+    // Add comparison bit if needed (bit 7)
+    if (useComparison)
+        filterValue |= 0x80;
+
+    return static_cast<D3D12_FILTER>(filterValue);
+}
+
+std::vector<D3D12_STATIC_SAMPLER_DESC> GetDX12StaticSamplersFromTextureSamplers(std::span<TextureSampler> samplers)
+{
+    std::vector<D3D12_STATIC_SAMPLER_DESC> dxSamplers;
+    dxSamplers.reserve(samplers.size());
+
+    for (u32 i = 0; i < samplers.size(); ++i)
+    {
+        dxSamplers.push_back({
+            .Filter = GetDX12FilterFromFilterMode(samplers[i].minFilter,
+                                                  samplers[i].magFilter,
+                                                  samplers[i].mipFilter,
+                                                  samplers[i].compareOp != CompareOp::Never),
+            .AddressU = GetDX12TextureAddressModeFromAddressMode(samplers[i].addressU),
+            .AddressV = GetDX12TextureAddressModeFromAddressMode(samplers[i].addressV),
+            .AddressW = GetDX12TextureAddressModeFromAddressMode(samplers[i].addressW),
+            .MipLODBias = samplers[i].mipLODBias,
+            .MaxAnisotropy = samplers[i].maxAnisotropy,
+            .ComparisonFunc = GraphicsPipeline::GetD3D12ComparisonFuncFromCompareOp(samplers[i].compareOp),
+            .BorderColor = GetDX12StaticBorderColorFromBorderColor(samplers[i].borderColor),
+            .MinLOD = samplers[i].minLOD,
+            .MaxLOD = samplers[i].maxLOD,
+            .ShaderRegister = i,
+            .RegisterSpace = 0,
+            .ShaderVisibility = D3D12_SHADER_VISIBILITY::D3D12_SHADER_VISIBILITY_ALL,
+        });
+    }
+
+    return dxSamplers;
+}
+
+} // namespace GraphicsPipeline
+
+} // namespace vex::dx12

--- a/src/DX12/DX12TextureSampler.h
+++ b/src/DX12/DX12TextureSampler.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <span>
+#include <vector>
+
+#include <Vex/TextureSampler.h>
+
+#include <DX12/DX12Headers.h>
+
+namespace vex::dx12
+{
+
+namespace GraphicsPipeline
+{
+
+D3D12_TEXTURE_ADDRESS_MODE GetDX12TextureAddressModeFromAddressMode(AddressMode addressMode);
+D3D12_STATIC_BORDER_COLOR GetDX12StaticBorderColorFromBorderColor(BorderColor borderColor);
+D3D12_FILTER GetDX12FilterFromFilterMode(FilterMode minFilter,
+                                         FilterMode magFilter,
+                                         FilterMode mipFilter,
+                                         bool useComparison = false);
+std::vector<D3D12_STATIC_SAMPLER_DESC> GetDX12StaticSamplersFromTextureSamplers(std::span<TextureSampler> samplers);
+
+} // namespace GraphicsPipeline
+
+} // namespace vex::dx12

--- a/src/Vex.h
+++ b/src/Vex.h
@@ -5,6 +5,8 @@
 #include <Vex/DrawHelpers.h>
 #include <Vex/FeatureChecker.h>
 #include <Vex/GfxBackend.h>
+#include <Vex/GraphicsPipeline.h>
+#include <Vex/TextureSampler.h>
 
 namespace vex
 {

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -264,6 +264,11 @@ void GfxBackend::SetShaderCompilationErrorsCallback(std::function<ShaderCompileE
     }
 }
 
+void GfxBackend::SetSamplers(std::span<TextureSampler> newSamplers)
+{
+    psCache.GetResourceLayout().SetSamplers(newSamplers);
+}
+
 void GfxBackend::RecompileChangedShaders()
 {
     if (description.enableShaderDebugging)

--- a/src/Vex/PipelineStateCache.cpp
+++ b/src/Vex/PipelineStateCache.cpp
@@ -27,8 +27,8 @@ RHIResourceLayout& PipelineStateCache::GetResourceLayout()
     return *resourceLayout;
 }
 
-const RHIGraphicsPipelineState* PipelineStateCache::GetGraphicsPipelineState(
-    const RHIGraphicsPipelineState::Key& key, const ShaderResourceContext& resourceContext)
+const RHIGraphicsPipelineState* PipelineStateCache::GetGraphicsPipelineState(const RHIGraphicsPipelineState::Key& key,
+                                                                             ShaderResourceContext resourceContext)
 {
     RHIGraphicsPipelineState* ps;
     if (graphicsPSCache.contains(key))
@@ -40,6 +40,9 @@ const RHIGraphicsPipelineState* PipelineStateCache::GetGraphicsPipelineState(
         graphicsPSCache[key] = rhi->CreateGraphicsPipelineState(key);
         ps = graphicsPSCache[key].get();
     }
+
+    // Add samplers to the resourceContext
+    resourceContext.samplers = resourceLayout->GetStaticSamplers();
 
     auto vertexShader = shaderCache.GetShader(ps->key.vertexShader, resourceContext);
     auto pixelShader = shaderCache.GetShader(ps->key.pixelShader, resourceContext);
@@ -64,7 +67,7 @@ const RHIGraphicsPipelineState* PipelineStateCache::GetGraphicsPipelineState(
 }
 
 const RHIComputePipelineState* PipelineStateCache::GetComputePipelineState(const RHIComputePipelineState::Key& key,
-                                                                           const ShaderResourceContext& resourceContext)
+                                                                           ShaderResourceContext resourceContext)
 {
     RHIComputePipelineState* ps;
     if (computePSCache.contains(key))
@@ -76,6 +79,9 @@ const RHIComputePipelineState* PipelineStateCache::GetComputePipelineState(const
         computePSCache[key] = rhi->CreateComputePipelineState(key);
         ps = computePSCache[key].get();
     }
+
+    // Add samplers to the resourceContext
+    resourceContext.samplers = resourceLayout->GetStaticSamplers();
 
     auto shader = shaderCache.GetShader(ps->key.computeShader, resourceContext);
     if (!shader->IsValid())

--- a/src/Vex/PipelineStateCache.h
+++ b/src/Vex/PipelineStateCache.h
@@ -7,6 +7,7 @@
 #include <Vex/RHI/RHIFwd.h>
 #include <Vex/RHI/RHIPipelineState.h>
 #include <Vex/ShaderCompiler.h>
+#include <Vex/ShaderResourceContext.h>
 #include <Vex/UniqueHandle.h>
 
 namespace vex
@@ -14,13 +15,14 @@ namespace vex
 
 struct ShaderKey;
 class FeatureChecker;
-struct ShaderResourceContext;
 
 class PipelineStateCache
 {
 public:
     PipelineStateCache() = default;
-    PipelineStateCache(RHI* rhi, RHIDescriptorPool& descriptorPool, const FeatureChecker& featureChecker,
+    PipelineStateCache(RHI* rhi,
+                       RHIDescriptorPool& descriptorPool,
+                       const FeatureChecker& featureChecker,
                        ResourceCleanup* resourceCleanup,
                        bool enableShaderDebugging);
     ~PipelineStateCache();
@@ -34,9 +36,9 @@ public:
     RHIResourceLayout& GetResourceLayout();
 
     const RHIGraphicsPipelineState* GetGraphicsPipelineState(const RHIGraphicsPipelineState::Key& key,
-                                                             const ShaderResourceContext& resourceContext);
+                                                             ShaderResourceContext resourceContext);
     const RHIComputePipelineState* GetComputePipelineState(const RHIComputePipelineState::Key& key,
-                                                           const ShaderResourceContext& resourceContext);
+                                                           ShaderResourceContext resourceContext);
 
     ShaderCache& GetShaderCache();
 

--- a/src/Vex/RHI/RHIResourceLayout.cpp
+++ b/src/Vex/RHI/RHIResourceLayout.cpp
@@ -6,6 +6,28 @@
 
 namespace vex
 {
+
+void RHIResourceLayout::SetSamplers(std::span<TextureSampler> newSamplers)
+{
+    // Validation of the sampler name.
+    for (auto& s : newSamplers)
+    {
+        if (s.name.empty())
+        {
+            VEX_LOG(Fatal,
+                    "Your sampler state must have a valid name, otherwise you cannot use the sampler in shaders!");
+        }
+    }
+
+    samplers = { newSamplers.begin(), newSamplers.end() };
+    isDirty = true;
+}
+
+std::span<const TextureSampler> RHIResourceLayout::GetStaticSamplers() const
+{
+    return { samplers.begin(), samplers.end() };
+}
+
 ScopedGlobalConstantHandle RHIResourceLayout::RegisterScopedGlobalConstant(GlobalConstant globalConstant)
 {
     std::string globalContantName = globalConstant.name;

--- a/src/Vex/RHI/RHIResourceLayout.h
+++ b/src/Vex/RHI/RHIResourceLayout.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include <Vex/TextureSampler.h>
 #include <Vex/Types.h>
 
 namespace vex
@@ -39,15 +41,13 @@ private:
     RHIResourceLayout& globalLayout;
 };
 
-struct ResourceSampler
-{
-    // TODO: implement samplers
-};
-
 class RHIResourceLayout
 {
 public:
     virtual ~RHIResourceLayout() = default;
+
+    void SetSamplers(std::span<TextureSampler> newSamplers);
+    std::span<const TextureSampler> GetStaticSamplers() const;
 
     ScopedGlobalConstantHandle RegisterScopedGlobalConstant(GlobalConstant globalConstant);
     GlobalConstantHandle RegisterGlobalConstant(GlobalConstant globalConstant);
@@ -66,7 +66,8 @@ public:
 protected:
     bool isDirty = true;
     std::unordered_map<std::string, GlobalConstant> globalConstants;
-    std::vector<ResourceSampler> samplers;
+
+    std::vector<TextureSampler> samplers;
 };
 
 } // namespace vex

--- a/src/Vex/ShaderGen.h
+++ b/src/Vex/ShaderGen.h
@@ -1,6 +1,8 @@
 #pragma once
 
 constexpr const char* ShaderGenGeneralMacros = R"(
+// GENERAL MACROS -------------------------
+
 #if defined(VEX_DX12)
 
 #define VEX_LOCAL_CONSTANT
@@ -13,6 +15,9 @@ constexpr const char* ShaderGenGeneralMacros = R"(
 )";
 
 constexpr const char* ShaderGenBindingMacros = R"(
+
+// BINDING MACROS -------------------------
+
 #if defined(VEX_DX12)
 
 #define VEX_GLOBAL_RESOURCE(type, name) static type name = ResourceDescriptorHeap[zzzZZZ___GeneratedConstantsCB.name##_bindlessIndex]

--- a/src/Vex/ShaderResourceContext.h
+++ b/src/Vex/ShaderResourceContext.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <Vex/RHI/RHIBindings.h>
+#include <Vex/TextureSampler.h>
 
 namespace vex
 {
@@ -13,6 +14,9 @@ struct ShaderResourceContext
 {
     std::span<RHITextureBinding> textures;
     std::span<RHIBufferBinding> buffers;
+
+    // Static samplers to include via codegen.
+    std::span<const TextureSampler> samplers;
 
     // TODO(https://trello.com/c/1eAuiBIJ): The nth dword after which the root/push constants contain bindless indices
     // (instead of local constants), for now unused and not filled in.

--- a/src/Vex/TextureSampler.h
+++ b/src/Vex/TextureSampler.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <string>
+
+#include <Vex/GraphicsPipeline.h>
+#include <Vex/Types.h>
+
+namespace vex
+{
+
+enum class FilterMode : u8
+{
+    Point,
+    Linear,
+    Anisotropic
+};
+
+enum class AddressMode : u8
+{
+    Wrap,
+    Mirror,
+    Clamp,
+    Border,
+    MirrorOnce
+};
+
+enum class BorderColor : u8
+{
+    TransparentBlackFloat,
+    TransparentBlackInt,
+    OpaqueBlackFloat,
+    OpaqueBlackInt,
+    OpaqueWhiteFloat,
+    OpaqueWhiteInt,
+};
+
+struct TextureSampler
+{
+    // Name of the sampler, the one that is used inside your shader.
+    std::string name;
+    FilterMode minFilter = FilterMode::Linear;
+    FilterMode magFilter = FilterMode::Linear;
+    FilterMode mipFilter = FilterMode::Linear;
+    AddressMode addressU = AddressMode::Wrap;
+    AddressMode addressV = AddressMode::Wrap;
+    AddressMode addressW = AddressMode::Wrap;
+    float mipLODBias = 0.0f;
+    u32 maxAnisotropy = 1;
+    CompareOp compareOp = CompareOp::Never;
+    BorderColor borderColor = BorderColor::TransparentBlackFloat;
+    float minLOD = 0.0f;
+    float maxLOD = std::numeric_limits<float>::max();
+};
+
+} // namespace vex

--- a/src/Vulkan/VkResourceLayout.cpp
+++ b/src/Vulkan/VkResourceLayout.cpp
@@ -25,6 +25,9 @@ VkResourceLayout::VkResourceLayout(::vk::Device device,
 
     pipelineLayout = VEX_VK_CHECK <<= device.createPipelineLayoutUnique(createInfo);
 
+    // TODO(https://trello.com/c/SQBSUKw9): Add sampler support on the Vulkan side. This class contains the samplers,
+    // now we just have to bind them.
+
     version++;
 }
 


### PR DESCRIPTION
Adds the possibility to add samplers to a shader. Currently they are auto generated, so the user just has to declare them on the C++ side and can then use them automatically in shaders.