### PR TITLE
Some explorations for the RHI refactor (using the RHICommandList and DX12CommandList)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,10 @@ add_library(Vex STATIC
     "src/Vex/TextureSampler.h"
     "src/Vex/GraphicsPipeline.h"
     "src/Vex/DrawHelpers.h"
- "src/Vex/ShaderCompilerSettings.h")
+    "src/Vex/ShaderCompilerSettings.h"
+    "src/RHIFwd.h"
+    "src/RHITypes.h" 
+)
 
 if(WIN32)
     target_sources(Vex PRIVATE

--- a/cmake/VexDX12.cmake
+++ b/cmake/VexDX12.cmake
@@ -74,7 +74,8 @@ function(setup_dx12_backend TARGET)
         "src/DX12/DX12States.cpp"
         "src/DX12/DX12GraphicsPipeline.h"
         "src/DX12/DX12GraphicsPipeline.cpp"
-    )
+        "src/DX12/DX12RHITypes.h"
+     "src/DX12/DX12RHIFwd.h")
 
     # Add DX12 sources to target
     target_sources(${TARGET} PRIVATE ${VEX_DX12_SOURCES})

--- a/src/DX12/DX12CommandList.h
+++ b/src/DX12/DX12CommandList.h
@@ -8,48 +8,43 @@
 namespace vex::dx12
 {
 
-class DX12CommandList : public RHICommandList
+class DX12CommandList final
 {
 public:
     DX12CommandList(const ComPtr<DX12Device>& device, CommandQueueType type);
-    virtual ~DX12CommandList() = default;
 
-    virtual bool IsOpen() const override;
+    bool IsOpen() const;
 
-    virtual void Open() override;
-    virtual void Close() override;
+    void Open();
+    void Close();
 
-    virtual void SetViewport(
-        float x, float y, float width, float height, float minDepth = 0.0f, float maxDepth = 1.0f) override;
-    virtual void SetScissor(i32 x, i32 y, u32 width, u32 height) override;
+    void SetViewport(float x, float y, float width, float height, float minDepth = 0.0f, float maxDepth = 1.0f);
+    void SetScissor(i32 x, i32 y, u32 width, u32 height);
 
-    virtual void SetPipelineState(const RHIGraphicsPipelineState& graphicsPipelineState) override;
-    virtual void SetPipelineState(const RHIComputePipelineState& computePipelineState) override;
+    void SetPipelineState(const RHIGraphicsPipelineState& graphicsPipelineState);
+    void SetPipelineState(const RHIComputePipelineState& computePipelineState);
 
-    virtual void SetLayout(RHIResourceLayout& layout) override;
-    virtual void SetLayoutLocalConstants(const RHIResourceLayout& layout,
-                                         std::span<const ConstantBinding> constants) override;
-    virtual void SetLayoutResources(const RHIResourceLayout& layout,
-                                    std::span<RHITextureBinding> textures,
-                                    std::span<RHIBufferBinding> buffers,
-                                    RHIDescriptorPool& descriptorPool) override;
-    virtual void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout) override;
-    virtual void SetInputAssembly(InputAssembly inputAssembly) override;
+    void SetLayout(RHIResourceLayout& layout);
+    void SetLayoutLocalConstants(const RHIResourceLayout& layout, std::span<const ConstantBinding> constants);
+    void SetLayoutResources(const RHIResourceLayout& layout,
+                            std::span<RHITextureBinding> textures,
+                            std::span<RHIBufferBinding> buffers,
+                            RHIDescriptorPool& descriptorPool);
+    void SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIResourceLayout& resourceLayout);
+    void SetInputAssembly(InputAssembly inputAssembly);
 
-    virtual void ClearTexture(RHITexture& rhiTexture,
-                              const ResourceBinding& clearBinding,
-                              const TextureClearValue& clearValue) override;
+    void ClearTexture(RHITexture& rhiTexture, const ResourceBinding& clearBinding, const TextureClearValue& clearValue);
 
-    virtual void Transition(RHITexture& texture, RHITextureState::Flags newState) override;
-    virtual void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs) override;
+    void Transition(RHITexture& texture, RHITextureState::Flags newState);
+    void Transition(std::span<std::pair<RHITexture&, RHITextureState::Flags>> textureNewStatePairs);
 
-    virtual void Draw(u32 vertexCount) override;
+    void Draw(u32 vertexCount);
 
-    virtual void Dispatch(const std::array<u32, 3>& groupCount) override;
+    void Dispatch(const std::array<u32, 3>& groupCount);
 
-    virtual void Copy(RHITexture& src, RHITexture& dst) override;
+    void Copy(RHITexture& src, RHITexture& dst);
 
-    virtual CommandQueueType GetType() const override;
+    CommandQueueType GetType() const;
 
 private:
     ComPtr<DX12Device> device;

--- a/src/DX12/DX12CommandPool.h
+++ b/src/DX12/DX12CommandPool.h
@@ -4,11 +4,12 @@
 #include <mutex>
 #include <vector>
 
+#include <RHIFwd.h>
 #include <Vex/RHI/RHI.h>
 #include <Vex/RHI/RHICommandPool.h>
 #include <Vex/UniqueHandle.h>
 
-#include <DX12/DX12CommandList.h>
+#include <DX12/DX12Headers.h>
 
 namespace vex::dx12
 {
@@ -24,14 +25,14 @@ public:
     virtual void ReclaimAllCommandListMemory() override;
 
 private:
-    std::vector<UniqueHandle<DX12CommandList>>& GetAvailableCommandLists(CommandQueueType queueType);
-    std::vector<UniqueHandle<DX12CommandList>>& GetOccupiedCommandLists(CommandQueueType queueType);
+    std::vector<UniqueHandle<RHICommandList>>& GetAvailableCommandLists(CommandQueueType queueType);
+    std::vector<UniqueHandle<RHICommandList>>& GetOccupiedCommandLists(CommandQueueType queueType);
 
     std::mutex poolMutex;
 
     ComPtr<DX12Device> device;
-    std::array<std::vector<UniqueHandle<DX12CommandList>>, CommandQueueTypes::Count> perQueueAvailableCommandLists;
-    std::array<std::vector<UniqueHandle<DX12CommandList>>, CommandQueueTypes::Count> perQueueOccupiedCommandLists;
+    std::array<std::vector<UniqueHandle<RHICommandList>>, CommandQueueTypes::Count> perQueueAvailableCommandLists;
+    std::array<std::vector<UniqueHandle<RHICommandList>>, CommandQueueTypes::Count> perQueueOccupiedCommandLists;
 };
 
 } // namespace vex::dx12

--- a/src/DX12/DX12RHI.cpp
+++ b/src/DX12/DX12RHI.cpp
@@ -16,6 +16,8 @@
 #include <DX12/DXGIFactory.h>
 #include <DX12/HRChecker.h>
 
+#include <RHITypes.h>
+
 namespace vex::dx12
 {
 
@@ -165,7 +167,7 @@ UniqueHandle<RHIDescriptorPool> DX12RHI::CreateDescriptorPool()
 
 void DX12RHI::ExecuteCommandList(RHICommandList& commandList)
 {
-    ID3D12CommandList* p = static_cast<DX12CommandList&>(commandList).commandList.Get();
+    ID3D12CommandList* p = commandList.commandList.Get();
     queues[commandList.GetType()]->ExecuteCommandLists(1, &p);
 }
 
@@ -174,8 +176,7 @@ void DX12RHI::ExecuteCommandLists(std::span<RHICommandList*> commandLists)
     std::array<std::vector<ID3D12CommandList*>, CommandQueueTypes::Count> rawCommandListsPerQueue;
     for (RHICommandList* cmdList : commandLists)
     {
-        rawCommandListsPerQueue[cmdList->GetType()].push_back(
-            reinterpret_cast<DX12CommandList*>(cmdList)->commandList.Get());
+        rawCommandListsPerQueue[cmdList->GetType()].push_back(cmdList->commandList.Get());
     }
 
     for (u32 i = 0; i < CommandQueueTypes::Count; ++i)

--- a/src/DX12/DX12RHIFwd.h
+++ b/src/DX12/DX12RHIFwd.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace vex::dx12
+{
+
+class DX12CommandList;
+
+}
+
+namespace vex
+{
+
+using RHICommandList = dx12::DX12CommandList;
+
+}

--- a/src/DX12/DX12RHITypes.h
+++ b/src/DX12/DX12RHITypes.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <DX12/DX12CommandList.h>

--- a/src/RHIFwd.h
+++ b/src/RHIFwd.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if VEX_DX12
+#include <DX12/DX12RHIFwd.h>
+#elif VEX_VULKAN
+#include <Vulkan/VkRHIFwd.h>
+#else
+#error Must define at least one graphics API!
+#endif

--- a/src/RHITypes.h
+++ b/src/RHITypes.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if VEX_DX12
+#include <DX12/DX12RHITypes.h>
+#elif VEX_VULKAN
+#include <Vulkan/VkRHITypes.h>
+#else
+#error Must define at least one graphics API!
+#endif

--- a/src/Vex.cpp
+++ b/src/Vex.cpp
@@ -1,5 +1,6 @@
 #include "Vex.h"
 
+#include <RHITypes.h>
 #include <Vex/Logger.h>
 
 #if VEX_DX12
@@ -39,5 +40,7 @@ UniqueHandle<GfxBackend> CreateGraphicsBackend(const BackendDescription& descrip
 
     return backend;
 }
+
+static_assert(RHICommandListInterface<RHICommandList>);
 
 } // namespace vex

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -1,5 +1,6 @@
 #include "CommandContext.h"
 
+#include <RHITypes.h>
 #include <Vex/Bindings.h>
 #include <Vex/Debug.h>
 #include <Vex/DrawHelpers.h>

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <span>
 
+#include <RHIFwd.h>
 #include <Vex/GraphicsPipeline.h>
 #include <Vex/RHI/RHIFwd.h>
 #include <Vex/RHI/RHIPipelineState.h>

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -5,6 +5,7 @@
 
 #include <magic_enum/magic_enum.hpp>
 
+#include <RHITypes.h>
 #include <Vex/CommandContext.h>
 #include <Vex/FeatureChecker.h>
 #include <Vex/Logger.h>

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <vector>
 
+#include <RHIFwd.h>
 #include <Vex/Buffer.h>
 #include <Vex/CommandQueueType.h>
 #include <Vex/Containers/FreeList.h>
@@ -11,8 +12,8 @@
 #include <Vex/FrameResource.h>
 #include <Vex/PipelineStateCache.h>
 #include <Vex/PlatformWindow.h>
-#include <Vex/Resource.h>
 #include <Vex/RHI/RHIFwd.h>
+#include <Vex/Resource.h>
 #include <Vex/Texture.h>
 #include <Vex/UniqueHandle.h>
 

--- a/src/Vex/RHI/RHI.h
+++ b/src/Vex/RHI/RHI.h
@@ -9,6 +9,7 @@
 #include <Vex/Types.h>
 #include <Vex/UniqueHandle.h>
 
+#include <RHIFwd.h>
 #include <Vex/RHI/RHIFwd.h>
 
 namespace vex

--- a/src/Vex/RHI/RHICommandPool.h
+++ b/src/Vex/RHI/RHICommandPool.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <RHIFwd.h>
 #include <Vex/RHI/RHI.h>
 #include <Vex/UniqueHandle.h>
 
 namespace vex
 {
 
-class RHICommandList;
+// class RHICommandList;
 
 class RHICommandPool
 {

--- a/src/Vex/RHI/RHIFwd.h
+++ b/src/Vex/RHI/RHIFwd.h
@@ -8,7 +8,6 @@ using RHI = RenderHardwareInterface;
 class RHIBuffer;
 class RHIGraphicsPipelineState;
 class RHIComputePipelineState;
-class RHICommandList;
 class RHICommandPool;
 class RHIShader;
 class RHIFence;

--- a/src/Vex/RHI/RHISwapChain.h
+++ b/src/Vex/RHI/RHISwapChain.h
@@ -7,7 +7,6 @@
 
 namespace vex
 {
-class RHICommandList;
 
 class RHITexture;
 


### PR DESCRIPTION
This is a suggestion of how we could rework the RHI to leverage compile-time goodness.

NB: This is a proposal, I've had some fun with <concepts> here, but the main thing here to check out is the RHIFwd.h and RHITypes.h files and how they are used. 

This solution should allow us to remove almost all polymorphism in Vex, while also keeping compile times low since we forward declare all resources.

For the concepts: I use them to define an interface (or contract? searching for a term that would correctly define what the concept defines) of what the RHICommandList type should offer in terms of public methods and fields. This has the big disadvantage of not allowing for parameter names, I've instead inserted them as a comment after each parameter. 
Then, in Vex, we'd use the concept as a type everywhere, this means we will never mistakenly use api-specific code when manipulating RHI structures (because since we're doing a compile-time typedef, we technically have access to the API-specific fields).
This works to replace all our interfaces with concepts, however we also have abstract classes with actual behavior in certain RHI classes (eg: RHICommandPool or RHIShader), here are a few options:

## Option 1: Virtual? My best friend!
Keep the abstract classes/interfaces we currently have. This means we pay the "cost" of having virtual functions for abstract classes, but it avoids using the concept to define an interface, when a virtual pure class is the same but with better syntax.
This is my favoured solution, the concepts approach will probably not scale well and having everywhere use the typedef means that certain virtual function calls will probably be able to be inlined (if we set the DX/Vk classes as final).

## Option 2: The Interface Contract
Should RHI classes even have common behavior/data at all? If our RHI type requires heavy common code, maybe it should not be a RHI type class, at all? Quickly glancing at our RHI classes, most have some sort of behavior so this would render the conversion quite painful, exposing many different challenges of how to avoid code duplication, while also avoiding virtual functions.

## Option 3: The Cumbersome
For RHI classes that require additional behavior, we can create the following:
```cpp
// The same concept-interface as in DX12CommandList.h
template <class T>
concept RHICommandListInterface = requires(T t, const T ct) {
// ...
};

template <class Derived>requires RHICommandListInterface<Derived>
class RHICommandListCommon
{
// Methods and data common to both.
};
// Other file:
class DX12CommandList final : public RHICommandListCommon<DX12CommandList>
// RHIFwd.h
class DX12CommandList;
using RHICommandList = DX12CommandList;
// RHITypes.cpp
// Making sure all our using declarations correctly follow the concept.
static_assert(RHICommandListInterface<RHICommandList>);
```
The base class would not be allowed to have virtual functions. This means potentially two different structures for each RHI type... very cumbersome!

