### PR TITLE
Arbitrary Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,16 +23,6 @@ include(GitHooks)
 include(VexDXC)
 
 # =========================================
-# Set configuration flags
-# Debug: Full debug symbols
-# Development: Optimizations with some debug symbols
-# Shipping: Fully optimized build without debug symbols
-# =========================================
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DVEX_DEBUG=1 -DVEX_DEVELOPMENT=0 -DVEX_SHIPPING=0")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DVEX_DEBUG=0 -DVEX_DEVELOPMENT=1 -DVEX_SHIPPING=0")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DVEX_DEBUG=0 -DVEX_DEVELOPMENT=0 -DVEX_SHIPPING=1")
-
-# =========================================
 # Graphics Backend Selection
 # =========================================
 message(STATUS "Configuring graphics backend...")
@@ -235,6 +225,18 @@ add_header_only_dependency(Vex magic_enum "${magic_enum_SOURCE_DIR}" "include" "
 # =========================================
 # DEFINES
 # =========================================
+
+# =========================================
+# Set configuration defines
+# Debug: Full debug symbols
+# Development: Optimizations with some debug symbols
+# Shipping: Fully optimized build without debug symbols
+# =========================================
+target_compile_definitions(Vex PUBLIC
+    $<$<CONFIG:Debug>:VEX_DEBUG=1 VEX_DEVELOPMENT=0 VEX_SHIPPING=0>
+    $<$<CONFIG:RelWithDebInfo>:VEX_DEBUG=0 VEX_DEVELOPMENT=1 VEX_SHIPPING=0>
+    $<$<CONFIG:Release>:VEX_DEBUG=0 VEX_DEVELOPMENT=0 VEX_SHIPPING=1>
+)
 
 # Graphics API defines
 target_compile_definitions(Vex PUBLIC VEX_DX12=$<BOOL:${VEX_ENABLE_DX12}> VEX_VULKAN=$<BOOL:${VEX_ENABLE_VULKAN}>)

--- a/src/DX12/RHI/DX12CommandList.cpp
+++ b/src/DX12/RHI/DX12CommandList.cpp
@@ -258,7 +258,7 @@ void DX12CommandList::ClearTexture(RHITexture& rhiTexture,
                        "Clearing the color requires the TextureClear::ClearColor flag for texture: {}.",
                        desc.name);
             commandList->ClearRenderTargetView(rhiTexture.GetOrCreateRTVDSVView(device, dxTextureView),
-                                               clearValue.color,
+                                               clearValue.color.data(),
                                                0,
                                                nullptr);
         }

--- a/src/Vex/Texture.h
+++ b/src/Vex/Texture.h
@@ -63,7 +63,7 @@ END_VEX_ENUM_FLAGS();
 struct TextureClearValue
 {
     TextureClear::Flags flags = TextureClear::None;
-    float color[4];
+    std::array<float, 4> color;
     float depth;
     u8 stencil;
 };


### PR DESCRIPTION
I've started using Vex in my own renderer, Zest. In doing so I've noticed and fixed the following issues:
- Added depth stencil to DX12 implementation
- Changed clear color to use a std::array
- Executables that use Vex from outside the folder will now correctly have the build optimization flags (VEX_SHIPPING, VEX_DEVELOPMENT, VEX_DEBUG) correctly defined and set to their appropriate values.