### PR TITLE
User Bindless and Transitions

### DIFF
--- a/examples/hello_triangle/main.cpp
+++ b/examples/hello_triangle/main.cpp
@@ -1,9 +1,5 @@
 #include <HelloTriangleApplication.h>
 
-#include <iostream>
-
-#include <Vex.h>
-
 int main()
 {
     HelloTriangleApplication application;

--- a/examples/hello_triangle_graphics_pipeline/main.cpp
+++ b/examples/hello_triangle_graphics_pipeline/main.cpp
@@ -1,9 +1,5 @@
 #include <HelloTriangleGraphicsApplication.h>
 
-#include <iostream>
-
-#include <Vex.h>
-
 int main()
 {
     HelloTriangleGraphicsApplication application;

--- a/examples/imgui/main.cpp
+++ b/examples/imgui/main.cpp
@@ -1,4 +1,4 @@
-#include "ImGuiApplication.h"
+#include <ImGuiApplication.h>
 
 int main()
 {

--- a/src/DX12/RHI/DX12Buffer.cpp
+++ b/src/DX12/RHI/DX12Buffer.cpp
@@ -83,19 +83,7 @@ void DX12Buffer::Unmap()
     buffer->Unmap(0, &range);
 }
 
-void DX12Buffer::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
-{
-    for (BindlessHandle bindlessHandle : viewCache | std::views::values)
-    {
-        if (bindlessHandle != GInvalidBindlessHandle)
-        {
-            descriptorPool.FreeStaticDescriptor(bindlessHandle);
-        }
-    }
-    viewCache.clear();
-}
-
-BindlessHandle DX12Buffer::GetOrCreateBindlessView(BufferUsage::Type usage, DX12DescriptorPool& descriptorPool)
+BindlessHandle DX12Buffer::GetOrCreateBindlessView(BufferUsage::Type usage, RHIDescriptorPool& descriptorPool)
 {
     // Usage is the exact correct usage (no longer flags), so == is valid here.
     bool isSRVView = (usage == BufferUsage::ShaderRead) && (desc.usage & BufferUsage::ShaderRead);
@@ -177,6 +165,18 @@ BindlessHandle DX12Buffer::GetOrCreateBindlessView(BufferUsage::Type usage, DX12
 
     viewCache[usage] = handle;
     return handle;
+}
+
+void DX12Buffer::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
+{
+    for (BindlessHandle bindlessHandle : viewCache | std::views::values)
+    {
+        if (bindlessHandle != GInvalidBindlessHandle)
+        {
+            descriptorPool.FreeStaticDescriptor(bindlessHandle);
+        }
+    }
+    viewCache.clear();
 }
 
 } // namespace vex::dx12

--- a/src/DX12/RHI/DX12Buffer.h
+++ b/src/DX12/RHI/DX12Buffer.h
@@ -22,9 +22,9 @@ public:
 
     virtual std::span<u8> Map() override;
     virtual void Unmap() override;
-    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
-    BindlessHandle GetOrCreateBindlessView(BufferUsage::Type usage, DX12DescriptorPool& descriptorPool);
+    virtual BindlessHandle GetOrCreateBindlessView(BufferUsage::Type usage, RHIDescriptorPool& descriptorPool) override;
+    virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
     ID3D12Resource* GetRawBuffer()
     {

--- a/src/DX12/RHI/DX12Texture.h
+++ b/src/DX12/RHI/DX12Texture.h
@@ -5,6 +5,7 @@
 #include <Vex/Containers/FreeList.h>
 #include <Vex/Hash.h>
 #include <Vex/RHIFwd.h>
+#include <Vex/Resource.h>
 
 #include <RHI/RHITexture.h>
 
@@ -61,6 +62,9 @@ public:
     // Takes ownership of the passed in texture.
     DX12Texture(ComPtr<DX12Device>& device, std::string name, ComPtr<ID3D12Resource> rawTex);
     ~DX12Texture();
+    virtual BindlessHandle GetOrCreateBindlessView(const ResourceBinding& binding,
+                                                   TextureUsage::Type usage,
+                                                   RHIDescriptorPool& descriptorPool) override;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
     ID3D12Resource* GetRawTexture()
@@ -68,15 +72,14 @@ public:
         return texture.Get();
     }
 
-    CD3DX12_CPU_DESCRIPTOR_HANDLE GetOrCreateRTVDSVView(ComPtr<DX12Device>& device, DX12TextureView view);
-    BindlessHandle GetOrCreateBindlessView(ComPtr<DX12Device>& device,
-                                           DX12TextureView view,
-                                           DX12DescriptorPool& descriptorPool);
+    CD3DX12_CPU_DESCRIPTOR_HANDLE GetOrCreateRTVDSVView(DX12TextureView view);
 
     D3D12_RESOURCE_STATES state = D3D12_RESOURCE_STATE_COMMON;
 
 private:
     ComPtr<ID3D12Resource> texture;
+
+    ComPtr<DX12Device> device;
 
     struct CacheEntry
     {

--- a/src/RHI/RHIBuffer.h
+++ b/src/RHI/RHIBuffer.h
@@ -5,6 +5,7 @@
 #include <Vex/Buffer.h>
 #include <Vex/Debug.h>
 #include <Vex/RHIFwd.h>
+#include <Vex/Resource.h>
 #include <Vex/Types.h>
 #include <Vex/UniqueHandle.h>
 
@@ -54,6 +55,7 @@ public:
     virtual UniqueHandle<RHIBuffer> CreateStagingBuffer() = 0;
     virtual std::span<u8> Map() = 0;
     virtual void Unmap() = 0;
+    virtual BindlessHandle GetOrCreateBindlessView(BufferUsage::Type usage, RHIDescriptorPool& descriptorPool) = 0;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) = 0;
 
     [[nodiscard]] bool NeedsStagingBufferCopy() const noexcept

--- a/src/RHI/RHITexture.h
+++ b/src/RHI/RHITexture.h
@@ -11,15 +11,15 @@ namespace vex
 // clang-format off
 
 BEGIN_VEX_ENUM_FLAGS(RHITextureState, u8)
-    Common = 0,
-    RenderTarget = 1,
-    ShaderReadWrite = 2,
-    DepthWrite = 4,
-    DepthRead = 8,
-    ShaderResource = 16,
-    CopySource = 32,
-    CopyDest = 64,
-    Present = 128,
+    Common          = 0,
+    RenderTarget    = 1 << 0,
+    ShaderReadWrite = 1 << 1,
+    DepthWrite      = 1 << 2,
+    DepthRead       = 1 << 3,
+    ShaderResource  = 1 << 4,
+    CopySource      = 1 << 5,
+    CopyDest        = 1 << 6,
+    Present         = 1 << 7,
 END_VEX_ENUM_FLAGS();
 
 // clang-format on

--- a/src/RHI/RHITexture.h
+++ b/src/RHI/RHITexture.h
@@ -2,6 +2,7 @@
 
 #include <Vex/EnumFlags.h>
 #include <Vex/RHIFwd.h>
+#include <Vex/Resource.h>
 #include <Vex/Texture.h>
 #include <Vex/Types.h>
 
@@ -27,6 +28,9 @@ END_VEX_ENUM_FLAGS();
 class RHITextureInterface
 {
 public:
+    virtual BindlessHandle GetOrCreateBindlessView(const ResourceBinding& binding,
+                                                   TextureUsage::Type usage,
+                                                   RHIDescriptorPool& descriptorPool) = 0;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) = 0;
 
     const TextureDescription& GetDescription() const

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -434,6 +434,16 @@ void CommandContext::SetRenderTarget(const ResourceBinding& renderTarget)
     cmdList->SetLayoutResources(backend->psCache.GetResourceLayout(), { &rtBinding, 1 }, {}, *backend->descriptorPool);
 }
 
+void CommandContext::Transition(const Texture& texture, RHITextureState::Type newState)
+{
+    cmdList->Transition(backend->GetRHITexture(texture.handle), newState);
+}
+
+void CommandContext::Transition(const Buffer& buffer, RHIBufferState::Type newState)
+{
+    cmdList->Transition(backend->GetRHIBuffer(buffer.handle), newState);
+}
+
 RHICommandList& CommandContext::GetRHICommandList()
 {
     return *cmdList;

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -6,7 +6,9 @@
 #include <Vex/ShaderKey.h>
 #include <Vex/Types.h>
 
+#include <RHI/RHIBuffer.h>
 #include <RHI/RHIPipelineState.h>
+#include <RHI/RHITexture.h>
 
 namespace vex
 {
@@ -59,6 +61,26 @@ public:
     // Manually sets a target as the current render target.
     // Is done automatically by draw calls, so its generally not necessary to call this.
     void SetRenderTarget(const ResourceBinding& renderTarget);
+
+    // Allows you to transition the passed in texture to the correct state. Usually this is done automatically by Vex
+    // before any draws or dispatches for the resources you pass in.
+    //
+    // However, in the case you are leveraging bindless resources (VEX_GET_BINDLESS_RESOURCE), you are responsible for
+    // ensuring any used resources are in the correct state.
+    //
+    // This contains redundancy checks so feel free to call it even if the resource is potentially already in the
+    // desired state for correctness.
+    void Transition(const Texture& texture, RHITextureState::Type newState);
+
+    // Allows you to transition the passed in buffer to the correct state. Usually this is done automatically by Vex
+    // before any draws or dispatches for the resources you pass in.
+    //
+    // However, in the case you are leveraging bindless resources (VEX_GET_BINDLESS_RESOURCE), you are responsible for
+    // ensuring any used resources are in the correct state.
+    //
+    // This contains redundancy checks so feel free to call it even if the resource is potentially already in the
+    // desired state for correctness.
+    void Transition(const Buffer& buffer, RHIBufferState::Type newState);
 
     // Returns the RHI command list associated with this context (you should avoid using this unless you know
     // what you are doing).

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -229,6 +229,34 @@ void GfxBackend::DestroyTexture(const Texture& texture)
     textureRegistry.FreeElement(texture.handle);
 }
 
+void GfxBackend::DestroyBuffer(const Buffer& buffer)
+{
+    resourceCleanup.CleanupResource(std::move(bufferRegistry[buffer.handle]));
+    bufferRegistry.FreeElement(buffer.handle);
+}
+
+BindlessHandle GfxBackend::GetTextureBindlessHandle(const ResourceBinding& bindlessResource, TextureUsage::Type usage)
+{
+    if (!bindlessResource.IsTexture())
+    {
+        VEX_LOG(Fatal, "Your bindlessResource must have a texture set.");
+    }
+
+    auto& texture = GetRHITexture(bindlessResource.texture.handle);
+    return texture.GetOrCreateBindlessView(bindlessResource, usage, *descriptorPool);
+}
+
+BindlessHandle GfxBackend::GetBufferBindlessHandle(const ResourceBinding& bindlessResource, BufferUsage::Type usage)
+{
+    if (!bindlessResource.IsBuffer())
+    {
+        VEX_LOG(Fatal, "Your bindlessResource must have a buffer set.");
+    }
+
+    auto& buffer = GetRHIBuffer(bindlessResource.buffer.handle);
+    return buffer.GetOrCreateBindlessView(usage, *descriptorPool);
+}
+
 void GfxBackend::FlushGPU()
 {
     VEX_LOG(Info, "Forcing a GPU flush...");

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -73,6 +73,13 @@ public:
     // Once destroyed, the handle passed in is invalid and should no longer be used.
     void DestroyTexture(const Texture& texture);
 
+    // Destroys a buffer, the handle passed in must be the one obtained from calling CreateBuffer earlier.
+    // Once destroyed, the handle passed in is invalid and should no longer be used.
+    void DestroyBuffer(const Buffer& buffer);
+
+    BindlessHandle GetTextureBindlessHandle(const ResourceBinding& bindlessResource, TextureUsage::Type usage);
+    BindlessHandle GetBufferBindlessHandle(const ResourceBinding& bindlessResource, BufferUsage::Type usage);
+
     // Flushes all current GPU commands.
     void FlushGPU();
 

--- a/src/Vex/ShaderGen.h
+++ b/src/Vex/ShaderGen.h
@@ -18,10 +18,12 @@ constexpr const char* ShaderGenBindingMacros = R"(
 
 // BINDING MACROS -------------------------
 
+// Usage: VEX_GLOBAL_RESOURCE(StructuredBuffer<Colors>, ColorBuffer);
+// Can now use ColorBuffer in your code as any other StructuredBuffer.
 #define VEX_GLOBAL_RESOURCE(type, name) static type name = ResourceDescriptorHeap[zzzZZZ___GeneratedConstantsCB.name##_bindlessIndex]
 
-// TODO(https://trello.com/c/bIVo8EP9): Users could also eventually get the bindless index (eg for storing a StructuredBuffer of materials, each material having bindless indices towards its textures such as albedo.)
-// In this case they should use this macro to get the resource, this macro should contain additional checks to avoid using invalid handles (should it really? validation layers have become really good at detecting invalid usage of descriptors...).
-#define VEX_GET_BINDLESS_RESOURCE(type, index) ResourceDescriptorHeap[index];
+// Usage: StructuredBuffer<MyStruct> myStruct = VEX_GET_BINDLESS_RESOURCE(index);
+// Can now use myStruct in your code as any other StructuredBuffer.
+#define VEX_GET_BINDLESS_RESOURCE(index) ResourceDescriptorHeap[index];
 
 )";

--- a/src/Vulkan/RHI/VkBuffer.cpp
+++ b/src/Vulkan/RHI/VkBuffer.cpp
@@ -104,7 +104,7 @@ VkBuffer::VkBuffer(VkGPUContext& ctx, const BufferDescription& desc)
     VEX_VK_CHECK << ctx.device.bindBufferMemory(*buffer, *memory, 0);
 }
 
-BindlessHandle VkBuffer::GetOrCreateBindlessIndex(VkGPUContext& ctx, VkDescriptorPool& descriptorPool)
+BindlessHandle VkBuffer::GetOrCreateBindlessView(BufferUsage::Type, RHIDescriptorPool& descriptorPool)
 {
     if (bufferHandle)
     {

--- a/src/Vulkan/RHI/VkBuffer.h
+++ b/src/Vulkan/RHI/VkBuffer.h
@@ -29,8 +29,9 @@ class VkBuffer final : public RHIBufferInterface
 public:
     VkBuffer(VkGPUContext& ctx, const BufferDescription& desc);
 
-    BindlessHandle GetOrCreateBindlessIndex(VkGPUContext& ctx, VkDescriptorPool& descriptorPool);
+    virtual BindlessHandle GetOrCreateBindlessView(BufferUsage::Type, RHIDescriptorPool& descriptorPool) override;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
+
     ::vk::Buffer GetNativeBuffer();
 
     virtual std::span<u8> Map() override;

--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -322,6 +322,7 @@ UniqueHandle<RHITexture> VkRHI::CreateTexture(const TextureDescription& descript
 {
     return MakeUnique<VkImageTexture>(GetGPUContext(), TextureDescription(description));
 }
+
 UniqueHandle<RHIBuffer> VkRHI::CreateBuffer(const BufferDescription& description)
 {
     return MakeUnique<VkBuffer>(GetGPUContext(), description);

--- a/src/Vulkan/RHI/VkSwapChain.cpp
+++ b/src/Vulkan/RHI/VkSwapChain.cpp
@@ -189,7 +189,7 @@ UniqueHandle<RHITexture> VkSwapChain::CreateBackBuffer(u8 backBufferIndex)
         .format = VulkanToTextureFormat(surfaceFormat.format),
     };
 
-    return MakeUnique<VkBackbufferTexture>(std::move(desc), backbufferImages[backBufferIndex]);
+    return MakeUnique<VkBackbufferTexture>(ctx, std::move(desc), backbufferImages[backBufferIndex]);
 }
 
 void VkSwapChain::InitSwapchainResource(u32 inWidth, u32 inHeight)

--- a/src/Vulkan/RHI/VkTexture.h
+++ b/src/Vulkan/RHI/VkTexture.h
@@ -52,9 +52,13 @@ class VkDescriptorPool;
 class VkTexture : public RHITextureInterface
 {
 public:
+    VkTexture(VkGPUContext& ctx);
     virtual ~VkTexture() = default;
     virtual ::vk::Image GetResource() = 0;
 
+    virtual BindlessHandle GetOrCreateBindlessView(const ResourceBinding& binding,
+                                                   TextureUsage::Type usage,
+                                                   RHIDescriptorPool& descriptorPool) override;
     BindlessHandle GetOrCreateBindlessView(VkGPUContext& device,
                                            const VkTextureViewDesc& view,
                                            VkDescriptorPool& descriptorPool);
@@ -71,12 +75,15 @@ public:
         ::vk::UniqueImageView view;
     };
     std::unordered_map<VkTextureViewDesc, CacheEntry> cache;
+
+protected:
+    VkGPUContext& ctx;
 };
 
 class VkBackbufferTexture final : public VkTexture
 {
 public:
-    VkBackbufferTexture(TextureDescription&& description, ::vk::Image backbufferImage);
+    VkBackbufferTexture(VkGPUContext& ctx, TextureDescription&& description, ::vk::Image backbufferImage);
 
     virtual ::vk::Image GetResource() override
     {
@@ -90,8 +97,8 @@ class VkImageTexture final : public VkTexture
 {
 public:
     // Takes ownership of the image
-    VkImageTexture(const TextureDescription& description, ::vk::UniqueImage rawImage);
-    VkImageTexture(TextureDescription&& description, ::vk::UniqueImage rawImage);
+    VkImageTexture(VkGPUContext& ctx, const TextureDescription& description, ::vk::UniqueImage rawImage);
+    VkImageTexture(VkGPUContext& ctx, TextureDescription&& description, ::vk::UniqueImage rawImage);
 
     // Creates a new image from the description
     VkImageTexture(VkGPUContext& ctx, TextureDescription&& description);


### PR DESCRIPTION
- Users can now manually transition resources on a command context.
- Users can now manually obtain the bindless handle towards a certain resource. The user has the responsability of not using it after the resource itself is destroyed.
- Updated ShaderGen.h with an example per macro for our own sakes.
- Added a missing DestroyBuffer function in the GfxBackend.
- Reworked textures to store the GraphicsContext/Device passed in in the constructor. This allows for the RHI get bindless function to work without issues (previously these methods required the ctx/device).