### PR TITLE
Support of all buffer types

### DIFF
--- a/examples/hello_triangle/HelloTriangleShader.cs.hlsl
+++ b/examples/hello_triangle/HelloTriangleShader.cs.hlsl
@@ -4,8 +4,8 @@ struct Colors
 {
     float4 cols;
 };
-VEX_GLOBAL_RESOURCE(StructuredBuffer<Colors>, ColorBuffer);
-VEX_GLOBAL_RESOURCE(RWByteAddressBuffer, CommBuffer);
+VEX_GLOBAL_RESOURCE(ConstantBuffer<Colors>, ColorBuffer);
+VEX_GLOBAL_RESOURCE(RWStructuredBuffer<float4>, CommBuffer);
 
 // Sourced from IQuilez SDF functions
 float dot2(float2 v)
@@ -30,8 +30,8 @@ float sdf(float2 p)
     // Convert pixel coordinates to normalized space for opengl-based sdf function (-1 to 1)
     float2 uv = float2(dtid.xy) / max(width, height).xx * 2 - 1;
 
-    float4 color = ColorBuffer[0].cols;
-    CommBuffer.Store<float4>(0, float4(1, 1, 1, 1) - color);
+    float4 color = ColorBuffer.cols;
+    CommBuffer[0] = float4(1, 1, 1, 1) - color;
 
     uv.y += 0.25f;
     uv.y *= -1;

--- a/examples/hello_triangle/HelloTriangleShader2.cs.hlsl
+++ b/examples/hello_triangle/HelloTriangleShader2.cs.hlsl
@@ -1,7 +1,7 @@
 VEX_GLOBAL_RESOURCE(RWTexture2D<float4>, OutputTexture);
 VEX_GLOBAL_RESOURCE(Texture2D<float4>, SourceTexture);
 
-VEX_GLOBAL_RESOURCE(ByteAddressBuffer, CommBuffer);
+VEX_GLOBAL_RESOURCE(StructuredBuffer<float4>, CommBuffer);
 
 // Simple function to check if a point is inside a triangle
 bool IsInsideTriangle(float2 p, float2 v0, float2 v1, float2 v2)
@@ -37,7 +37,7 @@ bool IsInsideTriangle(float2 p, float2 v0, float2 v1, float2 v2)
     if (IsInsideTriangle(uv, v0, v1, v2) || IsInsideTriangle(uv - float2(1.15, 0), v0, v1, v2))
     {
         float3 color = float3(uv.x, uv.y, 1 - uv.x * uv.y);
-        OutputTexture[dtid.xy] = CommBuffer.Load<float4>(0);
+        OutputTexture[dtid.xy] = CommBuffer[0];
     }
     else
     {

--- a/src/DX12/RHI/DX12Buffer.h
+++ b/src/DX12/RHI/DX12Buffer.h
@@ -12,6 +12,29 @@ namespace vex
 {
 struct BufferDescription;
 }
+
+namespace vex::dx12
+{
+
+struct BufferViewCacheKey
+{
+    BufferBindingUsage usage;
+    u32 stride;
+
+    bool operator==(const BufferViewCacheKey& other) const = default;
+};
+
+} // namespace vex::dx12
+
+// clang-format off
+
+VEX_MAKE_HASHABLE(vex::dx12::BufferViewCacheKey,
+    VEX_HASH_COMBINE(seed, obj.usage);
+    VEX_HASH_COMBINE(seed, obj.stride);
+);
+
+// clang-format on
+
 namespace vex::dx12
 {
 
@@ -23,7 +46,7 @@ public:
     virtual std::span<u8> Map() override;
     virtual void Unmap() override;
 
-    virtual BindlessHandle GetOrCreateBindlessView(BufferUsage::Type usage, RHIDescriptorPool& descriptorPool) override;
+    virtual BindlessHandle GetOrCreateBindlessView(BufferBindingUsage usage, u32 stride, RHIDescriptorPool& descriptorPool) override;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
     ID3D12Resource* GetRawBuffer()
@@ -38,7 +61,7 @@ private:
 
     ComPtr<ID3D12Resource> buffer;
 
-    std::unordered_map<BufferUsage::Type, BindlessHandle> viewCache;
+    std::unordered_map<BufferViewCacheKey, BindlessHandle> viewCache;
 };
 
 } // namespace vex::dx12

--- a/src/DX12/RHI/DX12CommandList.cpp
+++ b/src/DX12/RHI/DX12CommandList.cpp
@@ -181,9 +181,10 @@ void DX12CommandList::SetLayoutResources(const RHIResourceLayout& layout,
         }
     }
 
-    for (auto& [binding, usage, buffer] : buffers)
+    for (auto& [binding, buffer] : buffers)
     {
-        bindlessHandles.push_back(buffer->GetOrCreateBindlessView(usage, descriptorPool).GetIndex());
+        bindlessHandles.push_back(
+            buffer->GetOrCreateBindlessView(binding.bufferUsage, binding.bufferStride, descriptorPool).GetIndex());
     }
 
     // Now we can bind the bindless textures as constants in our root constants!
@@ -424,7 +425,7 @@ void DX12CommandList::Copy(RHITexture& src, RHITexture& dst)
 
 void DX12CommandList::Copy(RHIBuffer& src, RHIBuffer& dst)
 {
-    VEX_NOT_YET_IMPLEMENTED();
+    commandList->CopyBufferRegion(dst.GetRawBuffer(), 0, src.GetRawBuffer(), 0, src.GetDescription().byteSize);
 }
 
 CommandQueueType DX12CommandList::GetType() const

--- a/src/DX12/RHI/DX12RHI.h
+++ b/src/DX12/RHI/DX12RHI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
 #include <Vex/RHIFwd.h>
 
@@ -54,6 +55,12 @@ public:
 
 private:
     bool enableGPUDebugLayer = false;
+
+    struct LiveObjectsReporter
+    {
+        ~LiveObjectsReporter();
+    };
+    std::optional<LiveObjectsReporter> liveObjectsReporter;
 
     ComPtr<DX12Device> device;
 

--- a/src/RHI/RHIBuffer.cpp
+++ b/src/RHI/RHIBuffer.cpp
@@ -44,7 +44,7 @@ MappedMemory RHIBufferInterface::GetMappedMemory()
     return MappedMemory(*static_cast<RHIBuffer*>(this), false);
 }
 
-vex::RHIBufferInterface::RHIBufferInterface(const BufferDescription& desc)
+RHIBufferInterface::RHIBufferInterface(const BufferDescription& desc)
     : desc{ desc }
 {
 }
@@ -52,7 +52,7 @@ vex::RHIBufferInterface::RHIBufferInterface(const BufferDescription& desc)
 bool RHIBufferInterface::ShouldUseStagingBuffer() const
 {
     // Any buffer which does not have CPUWrite requires a staging buffer for the upload of data.
-    return !(desc.usage & BufferUsage::CPUWrite);
+    return desc.memoryLocality != ResourceMemoryLocality::CPUWrite;
 }
 
 RHIBuffer* RHIBufferInterface::GetStagingBuffer()

--- a/src/RHI/RHIBuffer.h
+++ b/src/RHI/RHIBuffer.h
@@ -55,7 +55,7 @@ public:
     virtual UniqueHandle<RHIBuffer> CreateStagingBuffer() = 0;
     virtual std::span<u8> Map() = 0;
     virtual void Unmap() = 0;
-    virtual BindlessHandle GetOrCreateBindlessView(BufferUsage::Type usage, RHIDescriptorPool& descriptorPool) = 0;
+    virtual BindlessHandle GetOrCreateBindlessView(BufferBindingUsage usage, u32 stride, RHIDescriptorPool& descriptorPool) = 0;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) = 0;
 
     [[nodiscard]] bool NeedsStagingBufferCopy() const noexcept

--- a/src/Vex/Bindings.cpp
+++ b/src/Vex/Bindings.cpp
@@ -176,7 +176,7 @@ void ResourceBinding::ValidateResourceBindings(std::span<const ResourceBinding> 
                 depthStencilAlreadyFound = true;
             }
 
-            if (resource.bufferFlags != BufferBinding::None)
+            if (resource.bufferUsage != BufferBindingUsage::None)
             {
                 VEX_LOG(
                     Warning,
@@ -192,6 +192,14 @@ void ResourceBinding::ValidateResourceBindings(std::span<const ResourceBinding> 
                 VEX_LOG(Fatal,
                         "Invalid binding for resource \"{}\": The specified buffer cannot be bound for this type of "
                         "operation. Check the usage flags of your resource at creation.",
+                        resource.name);
+            }
+
+            if (!IsBindingUsageCompatibleWithBufferUsage(resource.buffer.description.usage, resource.bufferUsage))
+            {
+                VEX_LOG(Fatal,
+                        "Invalid binding for resource \"{}\": Binding usage must be compatible with buffer description "
+                        "usage.",
                         resource.name);
             }
 

--- a/src/Vex/Bindings.h
+++ b/src/Vex/Bindings.h
@@ -46,10 +46,14 @@ struct ResourceBinding
     // eg: VEX_RESOURCE(Texture2D<float3>, MyName);
     std::string name;
 
+    // The buffer to bind
     Buffer buffer;
-    BufferBinding::Flags bufferFlags;
+    // The usage to use in this binding. Needs to be part of the usages of the buffer description
+    BufferBindingUsage bufferUsage;
 
+    // The texture to bind
     Texture texture;
+    // Flags for binding the texture
     TextureBinding::Flags textureFlags;
 
     u32 mipBias = 0;
@@ -60,6 +64,9 @@ struct ResourceBinding
     // 0 means to use every slice.
     u32 sliceCount = 0;
 
+    // Stride of the buffer if necessary
+    u32 bufferStride = 0;
+
     [[nodiscard]] bool IsBuffer() const
     {
         return buffer.handle != GInvalidBufferHandle;
@@ -69,9 +76,11 @@ struct ResourceBinding
         return texture.handle != GInvalidTextureHandle;
     }
 
+    // Takes in an array of bindings and does some validation on them
+    // the passed in flags assure that the bindings can be used according to those flags
     static void ValidateResourceBindings(std::span<const ResourceBinding> bindings,
                                          TextureUsage::Flags validUsageFlags,
-                                         BufferUsage::Flags validBufferUsageFlags = BufferUsage::None);
+                                         BufferUsage::Flags validBufferUsageFlags = BufferUsage::GenericBuffer);
 };
 
 } // namespace vex

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -203,6 +203,8 @@ Texture GfxBackend::CreateTexture(TextureDescription description, ResourceLifeti
 
 Buffer GfxBackend::CreateBuffer(BufferDescription description, ResourceLifetime lifetime)
 {
+    ValidateBufferDescription(description);
+
     if (lifetime == ResourceLifetime::Dynamic)
     {
         // TODO: handle dynamic resources, includes specifying that the resource when bound should use dynamic bindless
@@ -246,7 +248,7 @@ BindlessHandle GfxBackend::GetTextureBindlessHandle(const ResourceBinding& bindl
     return texture.GetOrCreateBindlessView(bindlessResource, usage, *descriptorPool);
 }
 
-BindlessHandle GfxBackend::GetBufferBindlessHandle(const ResourceBinding& bindlessResource, BufferUsage::Type usage)
+BindlessHandle GfxBackend::GetBufferBindlessHandle(const ResourceBinding& bindlessResource, BufferBindingUsage usage, u32 stride)
 {
     if (!bindlessResource.IsBuffer())
     {
@@ -254,7 +256,7 @@ BindlessHandle GfxBackend::GetBufferBindlessHandle(const ResourceBinding& bindle
     }
 
     auto& buffer = GetRHIBuffer(bindlessResource.buffer.handle);
-    return buffer.GetOrCreateBindlessView(usage, *descriptorPool);
+    return buffer.GetOrCreateBindlessView(usage, stride, *descriptorPool);
 }
 
 void GfxBackend::FlushGPU()

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -78,7 +78,8 @@ public:
     void DestroyBuffer(const Buffer& buffer);
 
     BindlessHandle GetTextureBindlessHandle(const ResourceBinding& bindlessResource, TextureUsage::Type usage);
-    BindlessHandle GetBufferBindlessHandle(const ResourceBinding& bindlessResource, BufferUsage::Type usage);
+    // Stride needs to be set if usage == StructuredBuffer
+    BindlessHandle GetBufferBindlessHandle(const ResourceBinding& bindlessResource,  BufferBindingUsage usage, u32 stride = 0);
 
     // Flushes all current GPU commands.
     void FlushGPU();

--- a/src/Vex/RHIBindings.h
+++ b/src/Vex/RHIBindings.h
@@ -18,7 +18,6 @@ struct RHITextureBinding
 struct RHIBufferBinding
 {
     ResourceBinding binding;
-    BufferUsage::Type usage;
     RHIBuffer* buffer;
 };
 

--- a/src/Vex/Resource.h
+++ b/src/Vex/Resource.h
@@ -12,6 +12,13 @@ enum class ResourceLifetime : u8
     Dynamic, // Valid only for the current frame.
 };
 
+enum class ResourceMemoryLocality : u8
+{
+    GPUOnly,
+    CPURead,
+    CPUWrite,
+};
+
 struct BindlessHandle : Handle<BindlessHandle>
 {
 };

--- a/src/Vex/ResourceBindingSet.cpp
+++ b/src/Vex/ResourceBindingSet.cpp
@@ -10,8 +10,10 @@ namespace vex
 
 void ResourceBindingSet::ValidateBindings() const
 {
-    ResourceBinding::ValidateResourceBindings(reads, TextureUsage::ShaderRead, BufferUsage::ShaderRead);
-    ResourceBinding::ValidateResourceBindings(writes, TextureUsage::ShaderReadWrite, BufferUsage::ShaderReadWrite);
+    ResourceBinding::ValidateResourceBindings(reads,
+                                              TextureUsage::ShaderRead,
+                                              BufferUsage::UniformBuffer | BufferUsage::GenericBuffer);
+    ResourceBinding::ValidateResourceBindings(writes, TextureUsage::ShaderReadWrite, BufferUsage::ReadWriteBuffer);
 }
 
 void ResourceBindingSet::CollectRHIResources(GfxBackend& backend,
@@ -19,7 +21,7 @@ void ResourceBindingSet::CollectRHIResources(GfxBackend& backend,
                                              std::vector<RHITextureBinding>& textureBindings,
                                              std::vector<RHIBufferBinding>& bufferBindings,
                                              TextureUsage::Type textureUsage,
-                                             BufferUsage::Type bufferUsage)
+                                             BufferUsage::Flags bufferUsage)
 {
     textureBindings.reserve(textureBindings.size() + resources.size());
     bufferBindings.reserve(bufferBindings.size() + resources.size());
@@ -32,10 +34,10 @@ void ResourceBindingSet::CollectRHIResources(GfxBackend& backend,
             textureBindings.emplace_back(binding, textureUsage, &texture);
         }
 
-        if (binding.IsBuffer())
+        if (binding.IsBuffer() && IsBindingUsageCompatibleWithBufferUsage(bufferUsage, binding.bufferUsage))
         {
             auto& buffer = backend.GetRHIBuffer(binding.buffer.handle);
-            bufferBindings.emplace_back(binding, bufferUsage, &buffer);
+            bufferBindings.emplace_back(binding, &buffer);
         }
     }
 }

--- a/src/Vex/ResourceBindingSet.h
+++ b/src/Vex/ResourceBindingSet.h
@@ -21,7 +21,7 @@ public:
                                     std::vector<RHITextureBinding>& textureBindings,
                                     std::vector<RHIBufferBinding>& bufferBindings,
                                     TextureUsage::Type textureUsage,
-                                    BufferUsage::Type bufferUsage);
+                                    BufferUsage::Flags bufferUsage);
 
     std::vector<ResourceBinding> reads;
     std::vector<ResourceBinding> writes;

--- a/src/Vex/ShaderResourceContext.cpp
+++ b/src/Vex/ShaderResourceContext.cpp
@@ -18,7 +18,7 @@ std::vector<std::string> ShaderResourceContext::GenerateShaderBindings() const
 
     for (const auto& buf : buffers)
     {
-        if (buf.usage == BufferUsage::ShaderRead || buf.usage == BufferUsage::ShaderReadWrite)
+        if (buf.binding.bufferUsage != BufferBindingUsage::None)
         {
             names.emplace_back(buf.binding.name);
         }

--- a/src/Vulkan/RHI/VkBuffer.h
+++ b/src/Vulkan/RHI/VkBuffer.h
@@ -29,7 +29,7 @@ class VkBuffer final : public RHIBufferInterface
 public:
     VkBuffer(VkGPUContext& ctx, const BufferDescription& desc);
 
-    virtual BindlessHandle GetOrCreateBindlessView(BufferUsage::Type, RHIDescriptorPool& descriptorPool) override;
+    virtual BindlessHandle GetOrCreateBindlessView(BufferBindingUsage usage, u32 stride, RHIDescriptorPool& descriptorPool) override;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
     ::vk::Buffer GetNativeBuffer();

--- a/src/Vulkan/RHI/VkCommandList.cpp
+++ b/src/Vulkan/RHI/VkCommandList.cpp
@@ -142,9 +142,9 @@ void VkCommandList::SetLayoutResources(const RHIResourceLayout& layout,
         }
     }
 
-    for (auto& [binding, usage, buffer] : buffers)
+    for (auto& [binding, buffer] : buffers)
     {
-        const BindlessHandle handle = buffer->GetOrCreateBindlessView(usage, descriptorPool);
+        const BindlessHandle handle = buffer->GetOrCreateBindlessView(binding.bufferUsage, binding.bufferStride, descriptorPool);
         bindlessHandleIndices.push_back(handle.GetIndex());
     }
 
@@ -271,6 +271,10 @@ void VkCommandList::ClearTexture(RHITexture& rhiTexture,
     case ImageLayout::ePresentSrcKHR:
         barrier.dstAccessMask = AccessFlagBits2::eMemoryRead | AccessFlagBits2::eMemoryWrite;
         barrier.dstStageMask = PipelineStageFlagBits2::eAllCommands;
+        break;
+    case ImageLayout::eColorAttachmentOptimal:
+        barrier.dstAccessMask = AccessFlagBits2::eMemoryWrite;
+        barrier.dstStageMask = PipelineStageFlagBits2::eAllGraphics;
         break;
     default:
         VEX_ASSERT(false, "Transition source image layout not supported");

--- a/src/Vulkan/RHI/VkDescriptorPool.cpp
+++ b/src/Vulkan/RHI/VkDescriptorPool.cpp
@@ -148,17 +148,15 @@ void VkDescriptorPool::UpdateDescriptor(VkGPUContext& ctx,
 
 void VkDescriptorPool::UpdateDescriptor(VkGPUContext& ctx,
                                         BindlessHandle targetDescriptor,
+                                        ::vk::DescriptorType descType,
                                         ::vk::DescriptorBufferInfo createInfo)
 {
-    // This handles StructuredBuffer, RWStructuredBuffer, ByteAddressBuffer and RWByteAddressBuffer.
-    // TODO: support uniform buffers!
-    auto type = ::vk::DescriptorType::eStorageBuffer;
     const ::vk::WriteDescriptorSet writeSet{
         .dstSet = *bindlessSet,
         .dstBinding = 0,
         .dstArrayElement = targetDescriptor.GetIndex(),
         .descriptorCount = 1,
-        .descriptorType = type,
+        .descriptorType = descType,
         .pBufferInfo = &createInfo,
     };
 

--- a/src/Vulkan/RHI/VkDescriptorPool.h
+++ b/src/Vulkan/RHI/VkDescriptorPool.h
@@ -20,7 +20,10 @@ public:
                           BindlessHandle targetDescriptor,
                           ::vk::DescriptorImageInfo createInfo,
                           bool writeAccess);
-    void UpdateDescriptor(VkGPUContext& ctx, BindlessHandle targetDescriptor, ::vk::DescriptorBufferInfo createInfo);
+    void UpdateDescriptor(VkGPUContext& ctx,
+                          BindlessHandle targetDescriptor,
+                          ::vk::DescriptorType descType,
+                          ::vk::DescriptorBufferInfo createInfo);
 
 private:
     ::vk::Device device;

--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -213,17 +213,17 @@ void VkRHI::Init(const UniqueHandle<PhysicalDevice>& vexPhysicalDevice)
     featuresMutableDescriptors.mutableDescriptorType = true;
     if (featuresAccelerationStructure.has_value())
     {
-        featuresMutableDescriptors.pNext = featuresAccelerationStructure.value();
+        featuresMutableDescriptors.pNext = &featuresAccelerationStructure.value();
     }
 
     // Allows for null descriptors
     ::vk::PhysicalDeviceRobustness2FeaturesEXT featuresRobustness;
     featuresRobustness.nullDescriptor = true;
-    featuresRobustness.pNext = featuresMutableDescriptors;
+    featuresRobustness.pNext = &featuresMutableDescriptors;
 
     ::vk::PhysicalDeviceVulkan13Features features13;
     features13.synchronization2 = true;
-    features13.pNext = featuresRobustness;
+    features13.pNext = &featuresRobustness;
 
     ::vk::PhysicalDeviceVulkan12Features features12;
     features12.pNext = &features13;

--- a/src/Vulkan/RHI/VkSwapChain.cpp
+++ b/src/Vulkan/RHI/VkSwapChain.cpp
@@ -179,15 +179,14 @@ UniqueHandle<RHITexture> VkSwapChain::CreateBackBuffer(u8 backBufferIndex)
 {
     auto backbufferImages = VEX_VK_CHECK <<= ctx.device.getSwapchainImagesKHR(*swapchain);
 
-    TextureDescription desc{
-        .name = std::format("backbuffer_{}", backBufferIndex),
-        .type = TextureType::Texture2D,
-        .width = width,
-        .height = height,
-        .depthOrArraySize = 1,
-        .mips = 1,
-        .format = VulkanToTextureFormat(surfaceFormat.format),
-    };
+    TextureDescription desc{ .name = std::format("backbuffer_{}", backBufferIndex),
+                             .type = TextureType::Texture2D,
+                             .width = width,
+                             .height = height,
+                             .depthOrArraySize = 1,
+                             .mips = 1,
+                             .format = VulkanToTextureFormat(surfaceFormat.format),
+                             .usage = TextureUsage::RenderTarget | TextureUsage::ShaderRead };
 
     return MakeUnique<VkBackbufferTexture>(ctx, std::move(desc), backbufferImages[backBufferIndex]);
 }


### PR DESCRIPTION
This adds the support for all buffer types, readonly (ConstantBuffer, StructuredBuffer, ByteAddressBuffer) and readwrite (RWStructuredBuffer, RWByteAddressBuffer). This is done by separating the Usages possible with the buffer and how the buffer will be used when binding it to a shader.

I also added validation of the buffer desc at creation. It validates the name and the byte size for now.

I also moved the stride information to the ResourceBinding because its only need when creating the views on the buffers. This has a side effect of needing the specify the stride in the resource binding, but I think it makes sense if the user wants to use the same buffer for different purposes.