### PR TITLE
Changed RHITexture and RHIBuffer to be stack allocated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ add_library(Vex STATIC
     "src/Vex/ShaderCompilerSettings.h"
     "src/Vex/RenderExtension.h"
     "src/Vex/RenderExtension.cpp"
+    "src/Vex/Containers/MaybeUninitialized.h"
 )
 
 

--- a/src/DX12/RHI/DX12RHI.cpp
+++ b/src/DX12/RHI/DX12RHI.cpp
@@ -141,14 +141,14 @@ UniqueHandle<RHIResourceLayout> DX12RHI::CreateResourceLayout(RHIDescriptorPool&
     return MakeUnique<DX12ResourceLayout>(device);
 }
 
-UniqueHandle<RHITexture> DX12RHI::CreateTexture(const TextureDescription& description)
+RHITexture DX12RHI::CreateTexture(const TextureDescription& description)
 {
-    return MakeUnique<DX12Texture>(device, description);
+    return DX12Texture(device, description);
 }
 
-UniqueHandle<RHIBuffer> DX12RHI::CreateBuffer(const BufferDescription& description)
+RHIBuffer DX12RHI::CreateBuffer(const BufferDescription& description)
 {
-    return MakeUnique<DX12Buffer>(device, description);
+    return DX12Buffer(device, description);
 }
 
 UniqueHandle<RHIDescriptorPool> DX12RHI::CreateDescriptorPool()

--- a/src/DX12/RHI/DX12RHI.h
+++ b/src/DX12/RHI/DX12RHI.h
@@ -34,8 +34,8 @@ public:
     virtual RHIComputePipelineState CreateComputePipelineState(const ComputePipelineStateKey& key) override;
     virtual UniqueHandle<RHIResourceLayout> CreateResourceLayout(RHIDescriptorPool& descriptorPool) override;
 
-    virtual UniqueHandle<RHITexture> CreateTexture(const TextureDescription& description) override;
-    virtual UniqueHandle<RHIBuffer> CreateBuffer(const BufferDescription& description) override;
+    virtual RHITexture CreateTexture(const TextureDescription& description) override;
+    virtual RHIBuffer CreateBuffer(const BufferDescription& description) override;
 
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() override;
 

--- a/src/DX12/RHI/DX12SwapChain.cpp
+++ b/src/DX12/RHI/DX12SwapChain.cpp
@@ -80,12 +80,12 @@ bool DX12SwapChain::NeedsFlushForVSyncToggle()
     return false;
 }
 
-UniqueHandle<RHITexture> DX12SwapChain::CreateBackBuffer(u8 backBufferIndex)
+RHITexture DX12SwapChain::CreateBackBuffer(u8 backBufferIndex)
 {
     ComPtr<ID3D12Resource> backBuffer;
     chk << swapChain->GetBuffer(backBufferIndex, IID_PPV_ARGS(&backBuffer));
 
-    return MakeUnique<DX12Texture>(device, std::format("BackBuffer_{}", backBufferIndex), backBuffer);
+    return DX12Texture(device, std::format("BackBuffer_{}", backBufferIndex), backBuffer);
 }
 
 u8 DX12SwapChain::GetBackBufferCount(FrameBuffering frameBuffering)

--- a/src/DX12/RHI/DX12SwapChain.h
+++ b/src/DX12/RHI/DX12SwapChain.h
@@ -32,7 +32,7 @@ public:
     virtual void SetVSync(bool enableVSync) override;
     virtual bool NeedsFlushForVSyncToggle() override;
 
-    virtual UniqueHandle<RHITexture> CreateBackBuffer(u8 backBufferIndex) override;
+    virtual RHITexture CreateBackBuffer(u8 backBufferIndex) override;
 
 private:
     static u8 GetBackBufferCount(FrameBuffering frameBuffering);

--- a/src/DX12/RHI/DX12Texture.cpp
+++ b/src/DX12/RHI/DX12Texture.cpp
@@ -333,10 +333,6 @@ DX12Texture::DX12Texture(ComPtr<DX12Device>& device, std::string name, ComPtr<ID
 #endif
 }
 
-DX12Texture::~DX12Texture()
-{
-}
-
 BindlessHandle DX12Texture::GetOrCreateBindlessView(const ResourceBinding& binding,
                                                     TextureUsage::Type usage,
                                                     RHIDescriptorPool& descriptorPool)

--- a/src/DX12/RHI/DX12Texture.h
+++ b/src/DX12/RHI/DX12Texture.h
@@ -61,7 +61,7 @@ public:
     DX12Texture(ComPtr<DX12Device>& device, const TextureDescription& description);
     // Takes ownership of the passed in texture.
     DX12Texture(ComPtr<DX12Device>& device, std::string name, ComPtr<ID3D12Resource> rawTex);
-    ~DX12Texture();
+
     virtual BindlessHandle GetOrCreateBindlessView(const ResourceBinding& binding,
                                                    TextureUsage::Type usage,
                                                    RHIDescriptorPool& descriptorPool) override;

--- a/src/RHI/RHI.h
+++ b/src/RHI/RHI.h
@@ -34,8 +34,8 @@ struct RenderHardwareInterface
     virtual RHIComputePipelineState CreateComputePipelineState(const ComputePipelineStateKey& key) = 0;
     virtual UniqueHandle<RHIResourceLayout> CreateResourceLayout(RHIDescriptorPool& descriptorPool) = 0;
 
-    virtual UniqueHandle<RHITexture> CreateTexture(const TextureDescription& description) = 0;
-    virtual UniqueHandle<RHIBuffer> CreateBuffer(const BufferDescription& description) = 0;
+    virtual RHITexture CreateTexture(const TextureDescription& description) = 0;
+    virtual RHIBuffer CreateBuffer(const BufferDescription& description) = 0;
 
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() = 0;
 

--- a/src/RHI/RHIBuffer.h
+++ b/src/RHI/RHIBuffer.h
@@ -48,6 +48,13 @@ private:
 class RHIBufferInterface
 {
 public:
+    RHIBufferInterface() = default;
+    RHIBufferInterface(const RHIBufferInterface&) = delete;
+    RHIBufferInterface& operator=(const RHIBufferInterface&) = delete;
+    RHIBufferInterface(RHIBufferInterface&&) = default;
+    RHIBufferInterface& operator=(RHIBufferInterface&&) = default;
+    ~RHIBufferInterface() = default;
+
     // RAII safe version to access buffer memory
     MappedMemory GetMappedMemory();
 
@@ -55,7 +62,9 @@ public:
     virtual UniqueHandle<RHIBuffer> CreateStagingBuffer() = 0;
     virtual std::span<u8> Map() = 0;
     virtual void Unmap() = 0;
-    virtual BindlessHandle GetOrCreateBindlessView(BufferBindingUsage usage, u32 stride, RHIDescriptorPool& descriptorPool) = 0;
+    virtual BindlessHandle GetOrCreateBindlessView(BufferBindingUsage usage,
+                                                   u32 stride,
+                                                   RHIDescriptorPool& descriptorPool) = 0;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) = 0;
 
     [[nodiscard]] bool NeedsStagingBufferCopy() const noexcept

--- a/src/RHI/RHISwapChain.h
+++ b/src/RHI/RHISwapChain.h
@@ -27,7 +27,7 @@ public:
     virtual void SetVSync(bool enableVSync) = 0;
     virtual bool NeedsFlushForVSyncToggle() = 0;
 
-    virtual UniqueHandle<RHITexture> CreateBackBuffer(u8 backBufferIndex) = 0;
+    virtual RHITexture CreateBackBuffer(u8 backBufferIndex) = 0;
 };
 
 } // namespace vex

--- a/src/RHI/RHITexture.h
+++ b/src/RHI/RHITexture.h
@@ -28,6 +28,16 @@ END_VEX_ENUM_FLAGS();
 class RHITextureInterface
 {
 public:
+    RHITextureInterface() = default;
+
+    RHITextureInterface(const RHITextureInterface&) = delete;
+    RHITextureInterface& operator=(const RHITextureInterface&) = delete;
+
+    RHITextureInterface(RHITextureInterface&&) = default;
+    RHITextureInterface& operator=(RHITextureInterface&&) = default;
+
+    ~RHITextureInterface() = default;
+
     virtual BindlessHandle GetOrCreateBindlessView(const ResourceBinding& binding,
                                                    TextureUsage::Type usage,
                                                    RHIDescriptorPool& descriptorPool) = 0;

--- a/src/Vex/Containers/MaybeUninitialized.h
+++ b/src/Vex/Containers/MaybeUninitialized.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <optional>
+
+namespace vex
+{
+
+template <class T>
+using MaybeUninitialized = std::optional<T>;
+
+} // namespace vex

--- a/src/Vex/Containers/ResourceCleanup.cpp
+++ b/src/Vex/Containers/ResourceCleanup.cpp
@@ -1,62 +1,56 @@
 #include "ResourceCleanup.h"
 
 #include <Vex/Debug.h>
-#include <Vex/RHIImpl/RHIBuffer.h>
 #include <Vex/RHIImpl/RHIPipelineState.h>
-#include <Vex/RHIImpl/RHITexture.h>
 
 namespace vex
 {
+
+// All underlying types of the ResourceCleanup must be move assignable.
+static_assert(std::is_move_assignable_v<MaybeUninitialized<RHITexture>>);
+static_assert(std::is_move_assignable_v<RHITexture>);
+static_assert(std::is_move_assignable_v<MaybeUninitialized<RHIBuffer>>);
+static_assert(std::is_move_assignable_v<RHIBuffer>);
 
 ResourceCleanup::ResourceCleanup(i8 bufferingCount)
     : defaultLifespan(bufferingCount)
 {
 }
 
-void ResourceCleanup::CleanupResource(CleanupVariant resource)
+void ResourceCleanup::CleanupResource(CleanupVariant&& resource)
 {
     resourcesInFlight.emplace_back(std::move(resource), defaultLifespan);
 }
 
-void ResourceCleanup::CleanupResource(CleanupVariant resource, i8 lifespan)
+void ResourceCleanup::CleanupResource(CleanupVariant&& resource, i8 lifespan)
 {
     resourcesInFlight.emplace_back(std::move(resource), lifespan);
 }
 
 void ResourceCleanup::FlushResources(i8 flushCount, RHIDescriptorPool& descriptorPool)
 {
-    std::vector<CleanupVariant> resourcesToDestroy;
-    for (auto& [resource, lifespan] : resourcesInFlight)
+    for (size_t i = 0; i < resourcesInFlight.size(); ++i)
     {
+        auto& [resource, lifespan] = resourcesInFlight[i];
         lifespan = std::max(lifespan - flushCount, 0);
-    }
-
-    for (auto& [resource, lifespan] : resourcesInFlight)
-    {
-        if (lifespan == 0)
+        if (lifespan <= 0)
         {
             std::visit(
                 [&descriptorPool](auto& val)
                 {
-                    using T = std::decay_t<decltype(val)>;
-                    if constexpr (std::is_same_v<UniqueHandle<RHITexture>, T>)
+                    using T = std::remove_cvref_t<decltype(val)>;
+                    if constexpr (std::is_same_v<MaybeUninitialized<RHITexture>, T> or
+                                  std::is_same_v<MaybeUninitialized<RHIBuffer>, T>)
                     {
                         val->FreeBindlessHandles(descriptorPool);
-                    }
-                    else if constexpr (std::is_same_v<UniqueHandle<RHIBuffer>, T>)
-                    {
-                        VEX_NOT_YET_IMPLEMENTED();
-                    }
-                    else
-                    {
-                        // Nothing to do.
                     }
                 },
                 resource);
         }
     }
 
-    std::erase_if(resourcesInFlight, [](const std::pair<CleanupVariant, i8>& val) { return val.second == 0; });
+    std::erase_if(resourcesInFlight,
+                  [](const std::pair<CleanupVariant, i8>& elem) -> bool { return elem.second <= 0; });
 }
 
 } // namespace vex

--- a/src/Vex/Containers/ResourceCleanup.h
+++ b/src/Vex/Containers/ResourceCleanup.h
@@ -3,7 +3,10 @@
 #include <variant>
 #include <vector>
 
+#include <Vex/Containers/MaybeUninitialized.h>
 #include <Vex/RHIFwd.h>
+#include <Vex/RHIImpl/RHIBuffer.h>
+#include <Vex/RHIImpl/RHITexture.h>
 #include <Vex/Types.h>
 #include <Vex/UniqueHandle.h>
 
@@ -13,14 +16,14 @@ namespace vex
 class ResourceCleanup
 {
 public:
-    using CleanupVariant = std::variant<UniqueHandle<RHITexture>,
-                                        UniqueHandle<RHIBuffer>,
+    using CleanupVariant = std::variant<MaybeUninitialized<RHITexture>,
+                                        MaybeUninitialized<RHIBuffer>,
                                         UniqueHandle<RHIGraphicsPipelineState>,
                                         UniqueHandle<RHIComputePipelineState>>;
     ResourceCleanup(i8 bufferingCount);
 
-    void CleanupResource(CleanupVariant resource);
-    void CleanupResource(CleanupVariant resource, i8 lifespan);
+    void CleanupResource(CleanupVariant&& resource);
+    void CleanupResource(CleanupVariant&& resource, i8 lifespan);
     void FlushResources(i8 flushCount, RHIDescriptorPool& descriptorPool);
 
 private:

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -13,6 +13,8 @@
 #include <Vex/PlatformWindow.h>
 #include <Vex/RHIFwd.h>
 #include <Vex/RHIImpl/RHI.h>
+#include <Vex/RHIImpl/RHIBuffer.h>
+#include <Vex/RHIImpl/RHITexture.h>
 #include <Vex/Resource.h>
 #include <Vex/Texture.h>
 #include <Vex/UniqueHandle.h>
@@ -79,7 +81,9 @@ public:
 
     BindlessHandle GetTextureBindlessHandle(const ResourceBinding& bindlessResource, TextureUsage::Type usage);
     // Stride needs to be set if usage == StructuredBuffer
-    BindlessHandle GetBufferBindlessHandle(const ResourceBinding& bindlessResource,  BufferBindingUsage usage, u32 stride = 0);
+    BindlessHandle GetBufferBindlessHandle(const ResourceBinding& bindlessResource,
+                                           BufferBindingUsage usage,
+                                           u32 stride = 0);
 
     // Flushes all current GPU commands.
     void FlushGPU();
@@ -151,8 +155,8 @@ private:
     std::vector<Texture> backBuffers;
 
     // Converts from the Handle to the actual underlying RHI resource.
-    FreeList<UniqueHandle<RHITexture>, TextureHandle> textureRegistry;
-    FreeList<UniqueHandle<RHIBuffer>, BufferHandle> bufferRegistry;
+    FreeList<RHITexture, TextureHandle> textureRegistry;
+    FreeList<RHIBuffer, BufferHandle> bufferRegistry;
 
     // We submit our command lists in batch at the end of the frame, to reduce driver overhead.
     std::vector<RHICommandList*> queuedCommandLists;

--- a/src/Vulkan/RHI/VkBuffer.h
+++ b/src/Vulkan/RHI/VkBuffer.h
@@ -29,7 +29,9 @@ class VkBuffer final : public RHIBufferInterface
 public:
     VkBuffer(VkGPUContext& ctx, const BufferDescription& desc);
 
-    virtual BindlessHandle GetOrCreateBindlessView(BufferBindingUsage usage, u32 stride, RHIDescriptorPool& descriptorPool) override;
+    virtual BindlessHandle GetOrCreateBindlessView(BufferBindingUsage usage,
+                                                   u32 stride,
+                                                   RHIDescriptorPool& descriptorPool) override;
     virtual void FreeBindlessHandles(RHIDescriptorPool& descriptorPool) override;
 
     ::vk::Buffer GetNativeBuffer();
@@ -42,7 +44,7 @@ private:
 
     ::vk::UniqueBuffer buffer;
     ::vk::UniqueDeviceMemory memory;
-    VkGPUContext& ctx;
+    VkGPUContext* ctx;
 
     std::optional<BindlessHandle> bufferHandle;
 

--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -320,14 +320,14 @@ UniqueHandle<RHIResourceLayout> VkRHI::CreateResourceLayout(RHIDescriptorPool& d
     return MakeUnique<VkResourceLayout>(*device, descriptorPool);
 }
 
-UniqueHandle<RHITexture> VkRHI::CreateTexture(const TextureDescription& description)
+RHITexture VkRHI::CreateTexture(const TextureDescription& description)
 {
-    return MakeUnique<VkImageTexture>(GetGPUContext(), TextureDescription(description));
+    return VkTexture(GetGPUContext(), TextureDescription(description));
 }
 
-UniqueHandle<RHIBuffer> VkRHI::CreateBuffer(const BufferDescription& description)
+RHIBuffer VkRHI::CreateBuffer(const BufferDescription& description)
 {
-    return MakeUnique<VkBuffer>(GetGPUContext(), description);
+    return VkBuffer(GetGPUContext(), description);
 }
 
 UniqueHandle<RHIDescriptorPool> VkRHI::CreateDescriptorPool()

--- a/src/Vulkan/RHI/VkRHI.h
+++ b/src/Vulkan/RHI/VkRHI.h
@@ -39,8 +39,8 @@ public:
     virtual RHIComputePipelineState CreateComputePipelineState(const ComputePipelineStateKey& key) override;
     virtual UniqueHandle<RHIResourceLayout> CreateResourceLayout(RHIDescriptorPool& descriptorPool) override;
 
-    virtual UniqueHandle<RHITexture> CreateTexture(const TextureDescription& description) override;
-    virtual UniqueHandle<RHIBuffer> CreateBuffer(const BufferDescription& description) override;
+    virtual RHITexture CreateTexture(const TextureDescription& description) override;
+    virtual RHIBuffer CreateBuffer(const BufferDescription& description) override;
 
     virtual UniqueHandle<RHIDescriptorPool> CreateDescriptorPool() override;
 

--- a/src/Vulkan/RHI/VkSwapChain.cpp
+++ b/src/Vulkan/RHI/VkSwapChain.cpp
@@ -175,7 +175,7 @@ bool VkSwapChain::NeedsFlushForVSyncToggle()
     return true;
 }
 
-UniqueHandle<RHITexture> VkSwapChain::CreateBackBuffer(u8 backBufferIndex)
+RHITexture VkSwapChain::CreateBackBuffer(u8 backBufferIndex)
 {
     auto backbufferImages = VEX_VK_CHECK <<= ctx.device.getSwapchainImagesKHR(*swapchain);
 
@@ -188,7 +188,7 @@ UniqueHandle<RHITexture> VkSwapChain::CreateBackBuffer(u8 backBufferIndex)
                              .format = VulkanToTextureFormat(surfaceFormat.format),
                              .usage = TextureUsage::RenderTarget | TextureUsage::ShaderRead };
 
-    return MakeUnique<VkBackbufferTexture>(ctx, std::move(desc), backbufferImages[backBufferIndex]);
+    return VkTexture(ctx, std::move(desc), backbufferImages[backBufferIndex]);
 }
 
 void VkSwapChain::InitSwapchainResource(u32 inWidth, u32 inHeight)

--- a/src/Vulkan/RHI/VkSwapChain.h
+++ b/src/Vulkan/RHI/VkSwapChain.h
@@ -40,7 +40,7 @@ public:
     virtual void SetVSync(bool enableVSync) override;
     virtual bool NeedsFlushForVSyncToggle() override;
 
-    virtual UniqueHandle<RHITexture> CreateBackBuffer(u8 backBufferIndex) override;
+    virtual RHITexture CreateBackBuffer(u8 backBufferIndex) override;
 
 private:
     void InitSwapchainResource(u32 width, u32 height);

--- a/src/Vulkan/RHI/VkTexture.cpp
+++ b/src/Vulkan/RHI/VkTexture.cpp
@@ -13,7 +13,7 @@
 namespace vex::vk
 {
 
-::vk::ImageViewType TextureTypeToVulkan(TextureViewType type)
+static ::vk::ImageViewType TextureTypeToVulkan(TextureViewType type)
 {
     switch (type)
     {
@@ -67,39 +67,60 @@ namespace vex::vk
 //     return *sampler;
 // }
 
-VkTexture::VkTexture(VkGPUContext& ctx)
-    : ctx(ctx)
-{
-}
-
-VkBackbufferTexture::VkBackbufferTexture(VkGPUContext& ctx,
-                                         TextureDescription&& inDescription,
-                                         ::vk::Image backbufferImage)
-    : VkTexture(ctx)
+VkTexture::VkTexture(VkGPUContext& ctx, TextureDescription&& inDescription, ::vk::Image backbufferImage)
+    : ctx(&ctx)
+    , type(BackBuffer)
     , image{ backbufferImage }
 {
     description = std::move(inDescription);
 }
 
-VkImageTexture::VkImageTexture(VkGPUContext& ctx, const TextureDescription& inDescription, ::vk::UniqueImage rawImage)
-    : VkTexture(ctx)
+VkTexture::VkTexture(VkGPUContext& ctx, const TextureDescription& inDescription, ::vk::UniqueImage rawImage)
+    : ctx(&ctx)
+    , type(Image)
     , image{ std::move(rawImage) }
 {
     description = inDescription;
 }
 
-VkImageTexture::VkImageTexture(VkGPUContext& ctx, TextureDescription&& inDescription, ::vk::UniqueImage rawImage)
-    : VkTexture(ctx)
+VkTexture::VkTexture(VkGPUContext& ctx, TextureDescription&& inDescription, ::vk::UniqueImage rawImage)
+    : ctx(&ctx)
+    , type(Image)
     , image{ std::move(rawImage) }
 {
     description = std::move(inDescription);
 }
 
-VkImageTexture::VkImageTexture(VkGPUContext& ctx, TextureDescription&& inDescription)
-    : VkTexture(ctx)
+VkTexture::VkTexture(VkGPUContext& ctx, TextureDescription&& inDescription)
+    : ctx(&ctx)
+    , type(Image)
 {
     description = std::move(inDescription);
-    CreateImage(ctx);
+    CreateImage();
+}
+
+::vk::Image VkTexture::GetResource()
+{
+    ::vk::Image returnVal;
+    std::visit(
+        [this, &returnVal](auto& val)
+        {
+            using T = std::remove_cvref_t<decltype(val)>;
+            if constexpr (std::is_same_v<T, ::vk::UniqueImage>)
+            {
+                returnVal = *val;
+            }
+            else if constexpr (std::is_same_v<T, ::vk::Image>)
+            {
+                returnVal = val;
+            }
+            else
+            {
+                VEX_LOG(Fatal, "Unsupported type for VkTexture::GetResource()");
+            }
+        },
+        image);
+    return returnVal;
 }
 
 BindlessHandle VkTexture::GetOrCreateBindlessView(const ResourceBinding& binding,
@@ -131,11 +152,11 @@ BindlessHandle VkTexture::GetOrCreateBindlessView(const ResourceBinding& binding
                                                     .layerCount = view.sliceCount,
                                                 } };
 
-    ::vk::UniqueImageView imageView = VEX_VK_CHECK <<= ctx.device.createImageViewUnique(viewCreate);
+    ::vk::UniqueImageView imageView = VEX_VK_CHECK <<= ctx->device.createImageViewUnique(viewCreate);
     const BindlessHandle handle = descriptorPool.AllocateStaticDescriptor();
 
     descriptorPool.UpdateDescriptor(
-        ctx,
+        *ctx,
         handle,
         ::vk::DescriptorImageInfo{ .sampler = nullptr, .imageView = *imageView, .imageLayout = GetLayout() },
         view.usage & TextureUsage::ShaderReadWrite);
@@ -172,7 +193,7 @@ BindlessHandle VkTexture::GetOrCreateBindlessView(const ResourceBinding& binding
                                                     .layerCount = view.sliceCount,
                                                 } };
 
-    ::vk::UniqueImageView imageView = VEX_VK_CHECK <<= ctx.device.createImageViewUnique(viewCreate);
+    ::vk::UniqueImageView imageView = VEX_VK_CHECK <<= ctx->device.createImageViewUnique(viewCreate);
 
     ::vk::ImageView ret = *imageView;
     viewCache[view] = std::move(imageView);
@@ -201,8 +222,14 @@ void VkTexture::FreeBindlessHandles(RHIDescriptorPool& descriptorPool)
     bindlessCache.clear();
 }
 
-void VkImageTexture::CreateImage(VkGPUContext& ctx)
+void VkTexture::CreateImage()
 {
+    if (type != Image)
+    {
+        VEX_LOG(Fatal, "Calling create texture with an unsupported type is not valid behavior.");
+        return;
+    }
+
     ::vk::ImageCreateInfo createInfo{};
     createInfo.format = TextureFormatToVulkan(description.format);
     createInfo.sharingMode = ::vk::SharingMode::eExclusive;
@@ -249,19 +276,21 @@ void VkImageTexture::CreateImage(VkGPUContext& ctx)
     createInfo.usage |= ::vk::ImageUsageFlagBits::eTransferDst;
     createInfo.usage |= ::vk::ImageUsageFlagBits::eTransferSrc;
 
-    image = VEX_VK_CHECK <<= ctx.device.createImageUnique(createInfo);
+    ::vk::UniqueImage imageTmp = VEX_VK_CHECK <<= ctx->device.createImageUnique(createInfo);
 
-    ::vk::MemoryRequirements imageMemoryReq = ctx.device.getImageMemoryRequirements(*image);
+    ::vk::MemoryRequirements imageMemoryReq = ctx->device.getImageMemoryRequirements(*imageTmp);
 
     // memory allocation should be done elsewhere in a central place
     ::vk::MemoryAllocateInfo allocateInfo{
         .allocationSize = imageMemoryReq.size,
-        .memoryTypeIndex = GetBestMemoryType(ctx.physDevice,
+        .memoryTypeIndex = GetBestMemoryType(ctx->physDevice,
                                              imageMemoryReq.memoryTypeBits,
                                              ::vk::MemoryPropertyFlagBits::eDeviceLocal),
     };
-    memory = VEX_VK_CHECK <<= ctx.device.allocateMemoryUnique(allocateInfo);
-    VEX_VK_CHECK << ctx.device.bindImageMemory(*image, *memory, 0);
+    memory = VEX_VK_CHECK <<= ctx->device.allocateMemoryUnique(allocateInfo);
+    VEX_VK_CHECK << ctx->device.bindImageMemory(*imageTmp, *memory, 0);
+
+    image = std::move(imageTmp);
 }
 
 } // namespace vex::vk


### PR DESCRIPTION
- This leads to less allocations and better cache locality when accessing RHI resources.
- The FreeList container now uses std::optional<> allowing for default contruction of stack objects
- Made RHITexture and RHIBuffer default their move cstr/assignation and delete their copy cstr/assignation