### PR TITLE
Changed PSO hash use an API specific hash

### DIFF
--- a/src/DX12/RHI/DX12PipelineState.h
+++ b/src/DX12/RHI/DX12PipelineState.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstddef>
+
+#include <Vex/Hash.h>
+
 #include <RHI/RHIPipelineState.h>
 
 #include <DX12/DX12Headers.h>
@@ -10,6 +14,20 @@ namespace vex::dx12
 class DX12GraphicsPipelineState final : public RHIGraphicsPipelineStateBase
 {
 public:
+    using Hasher = decltype([](const Key& key) -> std::size_t
+    {
+        std::size_t seed = 0;
+        VEX_HASH_COMBINE(seed, key.vertexShader);
+        VEX_HASH_COMBINE(seed, key.pixelShader);
+        VEX_HASH_COMBINE(seed, key.vertexInputLayout);
+        VEX_HASH_COMBINE(seed, key.inputAssembly);
+        VEX_HASH_COMBINE(seed, key.rasterizerState);
+        VEX_HASH_COMBINE(seed, key.depthStencilState);
+        VEX_HASH_COMBINE(seed, key.colorBlendState);
+        VEX_HASH_COMBINE(seed, key.renderTargetState);
+        return seed;
+    });
+
     DX12GraphicsPipelineState(const ComPtr<DX12Device>& device, const Key& key);
     ~DX12GraphicsPipelineState();
 

--- a/src/RHI/RHIPipelineState.h
+++ b/src/RHI/RHIPipelineState.h
@@ -71,16 +71,6 @@ public:
 
 // clang-format off
 
-//VEX_MAKE_HASHABLE(vex::GraphicsPipelineStateKey, 
-//    VEX_HASH_COMBINE(seed, obj.vertexShader);
-//    VEX_HASH_COMBINE(seed, obj.pixelShader);
-//    VEX_HASH_COMBINE(seed, obj.vertexInputLayout);
-//    VEX_HASH_COMBINE(seed, obj.inputAssembly);
-//    VEX_HASH_COMBINE(seed, obj.rasterizerState);
-//    VEX_HASH_COMBINE(seed, obj.depthStencilState);
-//    VEX_HASH_COMBINE(seed, obj.colorBlendState);
-//    VEX_HASH_COMBINE(seed, obj.renderTargetState);
-//);
 
 VEX_MAKE_HASHABLE(vex::ComputePipelineStateKey, 
     VEX_HASH_COMBINE(seed, obj.computeShader);

--- a/src/RHI/RHIPipelineState.h
+++ b/src/RHI/RHIPipelineState.h
@@ -71,16 +71,16 @@ public:
 
 // clang-format off
 
-VEX_MAKE_HASHABLE(vex::GraphicsPipelineStateKey, 
-    VEX_HASH_COMBINE(seed, obj.vertexShader);
-    VEX_HASH_COMBINE(seed, obj.pixelShader);
-    VEX_HASH_COMBINE(seed, obj.vertexInputLayout);
-    VEX_HASH_COMBINE(seed, obj.inputAssembly);
-    VEX_HASH_COMBINE(seed, obj.rasterizerState);
-    VEX_HASH_COMBINE(seed, obj.depthStencilState);
-    VEX_HASH_COMBINE(seed, obj.colorBlendState);
-    VEX_HASH_COMBINE(seed, obj.renderTargetState);
-);
+//VEX_MAKE_HASHABLE(vex::GraphicsPipelineStateKey, 
+//    VEX_HASH_COMBINE(seed, obj.vertexShader);
+//    VEX_HASH_COMBINE(seed, obj.pixelShader);
+//    VEX_HASH_COMBINE(seed, obj.vertexInputLayout);
+//    VEX_HASH_COMBINE(seed, obj.inputAssembly);
+//    VEX_HASH_COMBINE(seed, obj.rasterizerState);
+//    VEX_HASH_COMBINE(seed, obj.depthStencilState);
+//    VEX_HASH_COMBINE(seed, obj.colorBlendState);
+//    VEX_HASH_COMBINE(seed, obj.renderTargetState);
+//);
 
 VEX_MAKE_HASHABLE(vex::ComputePipelineStateKey, 
     VEX_HASH_COMBINE(seed, obj.computeShader);
@@ -88,6 +88,10 @@ VEX_MAKE_HASHABLE(vex::ComputePipelineStateKey,
 
 VEX_FORMATTABLE(vex::GraphicsPipelineStateKey, "GraphicsPipelineKey(\n\tVS: \"{}\"\n\tPS: \"{}\"\n\t",
     obj.vertexShader, obj.pixelShader
+);
+
+VEX_FORMATTABLE(vex::ComputePipelineStateKey, "ComputePipelineKey(\n\tCS: \"{}\"\n\t",
+    obj.computeShader
 );
 
 // clang-format on

--- a/src/Vex/PipelineStateCache.cpp
+++ b/src/Vex/PipelineStateCache.cpp
@@ -49,8 +49,6 @@ const RHIGraphicsPipelineState* PipelineStateCache::GetGraphicsPipelineState(con
     pipelineStateStale |= vertexShader->version > ps.vertexShaderVersion;
     pipelineStateStale |= pixelShader->version > ps.pixelShaderVersion;
     pipelineStateStale |= resourceLayout->version > ps.rootSignatureVersion;
-    // TODO(https://trello.com/c/qdCLRSHl): add other fields, maybe via a custom == func?
-    // Or just accept new slot in the cache?
     if (pipelineStateStale)
     {
         // Avoids PSO being destroyed while frame is in flight.

--- a/src/Vex/PipelineStateCache.h
+++ b/src/Vex/PipelineStateCache.h
@@ -44,7 +44,8 @@ private:
 
     ShaderCompiler shaderCompiler;
     UniqueHandle<RHIResourceLayout> resourceLayout;
-    std::unordered_map<RHIGraphicsPipelineState::Key, RHIGraphicsPipelineState> graphicsPSCache;
+    std::unordered_map<RHIGraphicsPipelineState::Key, RHIGraphicsPipelineState, RHIGraphicsPipelineState::Hasher>
+        graphicsPSCache;
     std::unordered_map<RHIComputePipelineState::Key, RHIComputePipelineState> computePSCache;
 };
 

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -158,6 +158,7 @@ void VkGraphicsPipelineState::Compile(const Shader& vertexShader,
     std::vector<::vk::Format> attachmentFormats(key.renderTargetState.colorFormats.size());
     std::ranges::transform(key.renderTargetState.colorFormats, attachmentFormats.begin(), TextureFormatToVulkan);
 
+    // TODO(https://trello.com/c/2KeJ2cXy): Add depthAttachmentFormat and stencilAttachmentFormat support.
     const ::vk::PipelineRenderingCreateInfoKHR pipelineRenderingCI{
         .colorAttachmentCount = static_cast<u32>(attachmentFormats.size()),
         .pColorAttachmentFormats = attachmentFormats.data(),
@@ -199,8 +200,8 @@ void VkGraphicsPipelineState::Cleanup(ResourceCleanup& resourceCleanup)
 
 VkComputePipelineState::VkComputePipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache)
     : RHIComputePipelineStateInterface(key)
-    , PSOCache{ PSOCache }
     , device{ device }
+    , PSOCache{ PSOCache }
 {
 }
 

--- a/src/Vulkan/RHI/VkPipelineState.h
+++ b/src/Vulkan/RHI/VkPipelineState.h
@@ -9,10 +9,23 @@ namespace vex::vk
 
 class VkGraphicsPipelineState final : public RHIGraphicsPipelineStateBase
 {
-    ::vk::PipelineCache PSOCache;
-    ::vk::Device device;
-
 public:
+    using Hasher = decltype([](const Key& key) -> std::size_t
+    {
+        // TODO(https://trello.com/c/2KeJ2cXy): Determine which keys are not needed in Vulkan. 
+        // I'll let @alexandreLBarrett handle this since you implemented the Vk graphics code.
+        std::size_t seed = 0;
+        VEX_HASH_COMBINE(seed, key.vertexShader);
+        VEX_HASH_COMBINE(seed, key.pixelShader);
+        VEX_HASH_COMBINE(seed, key.vertexInputLayout);
+        // Input assembly is bound dynamically.
+        VEX_HASH_COMBINE(seed, key.rasterizerState);
+        VEX_HASH_COMBINE(seed, key.depthStencilState);
+        VEX_HASH_COMBINE(seed, key.colorBlendState);
+        VEX_HASH_COMBINE(seed, key.renderTargetState);
+        return seed;
+    });
+
     VkGraphicsPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache);
     VkGraphicsPipelineState(VkGraphicsPipelineState&&) = default;
     VkGraphicsPipelineState& operator=(VkGraphicsPipelineState&&) = default;
@@ -23,13 +36,14 @@ public:
     virtual void Cleanup(ResourceCleanup& resourceCleanup) override;
 
     ::vk::UniquePipeline graphicsPipeline;
+
+private:
+    ::vk::Device device;
+    ::vk::PipelineCache PSOCache;
 };
 
 class VkComputePipelineState final : public RHIComputePipelineStateInterface
 {
-    ::vk::PipelineCache PSOCache;
-    ::vk::Device device;
-
 public:
     VkComputePipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache);
     VkComputePipelineState(VkComputePipelineState&&) = default;
@@ -39,6 +53,10 @@ public:
     virtual void Cleanup(ResourceCleanup& resourceCleanup) override;
 
     ::vk::UniquePipeline computePipeline;
+
+private:
+    ::vk::Device device;
+    ::vk::PipelineCache PSOCache;
 };
 
 } // namespace vex::vk


### PR DESCRIPTION
This will avoid spending time hashing fields that serve no purpose for the API. Mainly a benefit for Vulkan, with dynamic rendering.