### PR TITLE
Various fixes following integration of Vex into my own renderer 

### DIFF
--- a/examples/hello_cube/HelloCube.cpp
+++ b/examples/hello_cube/HelloCube.cpp
@@ -172,7 +172,7 @@ HelloCubeApplication::HelloCubeApplication()
 
         // TODO(https://trello.com/c/L6TkjaGl): this causes a Vulkan synchronization error! Very probably some sort of
         // missing barrier stage. Upload a single RGBA pixel to position x=10, y=10.
-        std::vector<vex::u8> pixel{ 255, 255, 255, 255 };
+        std::array<vex::u8, 4> pixel{ 255, 255, 255, 255 };
         ctx.EnqueueDataUpload(
             uvGuideTexture,
             std::as_bytes(std::span(pixel)),
@@ -188,18 +188,10 @@ HelloCubeApplication::HelloCubeApplication()
         stbi_image_free(imageData);
     }
 
-    std::vector samplers{ vex::TextureSampler{
-                              .minFilter = vex::FilterMode::Linear,
-                              .magFilter = vex::FilterMode::Linear,
-                              .addressU = vex::AddressMode::Clamp,
-                              .addressV = vex::AddressMode::Clamp,
-                          },
-                          vex::TextureSampler{
-                              .minFilter = vex::FilterMode::Point,
-                              .magFilter = vex::FilterMode::Point,
-                              .addressU = vex::AddressMode::Clamp,
-                              .addressV = vex::AddressMode::Clamp,
-                          } };
+    std::array samplers{
+        vex::TextureSampler::CreateSampler(vex::FilterMode::Linear, vex::AddressMode::Clamp),
+        vex::TextureSampler::CreateSampler(vex::FilterMode::Point, vex::AddressMode::Clamp),
+    };
     graphics->SetSamplers(samplers);
 }
 

--- a/shaders/Vex.hlsli
+++ b/shaders/Vex.hlsli
@@ -7,3 +7,5 @@
 #endif
 
 #define GetBindlessResource(index) ResourceDescriptorHeap[index & 0x00FFFFFF];
+
+static const uint GInvalidBindlessHandle = ~0U;

--- a/shaders/Vex.slang
+++ b/shaders/Vex.slang
@@ -20,3 +20,5 @@ public DescriptorHandle<T> GetBindlessResource(uint index) where T : IOpaqueDesc
 {
     return { index & 0x00FFFFFF };
 }
+
+static const uint GInvalidBindlessHandle = ~0U;

--- a/src/DX12/DX12Formats.h
+++ b/src/DX12/DX12Formats.h
@@ -321,4 +321,74 @@ constexpr inline DXGI_FORMAT GetSRGBFormatForSRGBCompatibleDX12Format(DXGI_FORMA
     }
 }
 
+constexpr inline DXGI_FORMAT GetTypelessFormatForDepthStencilCompatibleDX12Format(DXGI_FORMAT format)
+{
+    switch (format)
+    {
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+        return DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
+    case DXGI_FORMAT_D32_FLOAT:
+        return DXGI_FORMAT_R32_TYPELESS;
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        return DXGI_FORMAT_R24G8_TYPELESS;
+    case DXGI_FORMAT_D16_UNORM:
+        return DXGI_FORMAT_R16_TYPELESS;
+    default:
+        return DXGI_FORMAT_UNKNOWN;
+    }
+}
+
+constexpr inline DXGI_FORMAT GetDX12FormatForShaderResourceViewFormat(DXGI_FORMAT typelessFormat)
+{
+    switch (typelessFormat)
+    {
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+        return DXGI_FORMAT_R32G32B32A32_FLOAT;
+    case DXGI_FORMAT_R32G32B32_TYPELESS:
+        return DXGI_FORMAT_R32G32B32_FLOAT;
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+        return DXGI_FORMAT_R16G16B16A16_UNORM;
+    case DXGI_FORMAT_R32G32_TYPELESS:
+        return DXGI_FORMAT_R32G32_FLOAT;
+    case DXGI_FORMAT_R32G8X24_TYPELESS:
+        return DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+        return DXGI_FORMAT_R10G10B10A2_UNORM;
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+        return DXGI_FORMAT_R8G8B8A8_UNORM;
+    case DXGI_FORMAT_R16G16_TYPELESS:
+        return DXGI_FORMAT_R16G16_UNORM;
+    case DXGI_FORMAT_R32_TYPELESS:
+        return DXGI_FORMAT_R32_FLOAT;
+    case DXGI_FORMAT_R24G8_TYPELESS:
+        return DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
+    case DXGI_FORMAT_R8G8_TYPELESS:
+        return DXGI_FORMAT_R8G8_UNORM;
+    case DXGI_FORMAT_R16_TYPELESS:
+        return DXGI_FORMAT_R16_UNORM;
+    case DXGI_FORMAT_R8_TYPELESS:
+        return DXGI_FORMAT_R8_UNORM;
+    case DXGI_FORMAT_BC1_TYPELESS:
+        return DXGI_FORMAT_BC1_UNORM;
+    case DXGI_FORMAT_BC2_TYPELESS:
+        return DXGI_FORMAT_BC2_UNORM;
+    case DXGI_FORMAT_BC3_TYPELESS:
+        return DXGI_FORMAT_BC3_UNORM;
+    case DXGI_FORMAT_BC4_TYPELESS:
+        return DXGI_FORMAT_BC4_UNORM;
+    case DXGI_FORMAT_BC5_TYPELESS:
+        return DXGI_FORMAT_BC5_UNORM;
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+        return DXGI_FORMAT_B8G8R8A8_UNORM;
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+        return DXGI_FORMAT_B8G8R8X8_UNORM;
+    case DXGI_FORMAT_BC6H_TYPELESS:
+        return DXGI_FORMAT_BC6H_UF16;
+    case DXGI_FORMAT_BC7_TYPELESS:
+        return DXGI_FORMAT_BC7_UNORM;
+    default:
+        // Return as-is if not typeless
+        return typelessFormat;
+    }
+}
 } // namespace vex::dx12

--- a/src/DX12/RHI/DX12CommandList.cpp
+++ b/src/DX12/RHI/DX12CommandList.cpp
@@ -358,7 +358,7 @@ void DX12CommandList::BeginRendering(const RHIDrawResources& resources)
     if (type == CommandQueueType::Graphics)
     {
         CD3DX12_CPU_DESCRIPTOR_HANDLE* dsvHandlePtr = dsvHandle.has_value() ? &dsvHandle.value() : nullptr;
-        commandList->OMSetRenderTargets(static_cast<u32>(rtvHandles.size()), rtvHandles.data(), true, dsvHandlePtr);
+        commandList->OMSetRenderTargets(static_cast<u32>(rtvHandles.size()), rtvHandles.data(), false, dsvHandlePtr);
     }
     else
     {

--- a/src/RHI/RHIResourceLayout.cpp
+++ b/src/RHI/RHIResourceLayout.cpp
@@ -42,7 +42,7 @@ void RHIResourceLayoutBase::SetLayoutResources(const std::optional<ConstantBindi
     }
 }
 
-void RHIResourceLayoutBase::SetSamplers(std::span<TextureSampler> newSamplers)
+void RHIResourceLayoutBase::SetSamplers(std::span<const TextureSampler> newSamplers)
 {
     samplers = { newSamplers.begin(), newSamplers.end() };
     isDirty = true;

--- a/src/RHI/RHIResourceLayout.h
+++ b/src/RHI/RHIResourceLayout.h
@@ -24,7 +24,7 @@ public:
     ~RHIResourceLayoutBase();
     void SetLayoutResources(const std::optional<ConstantBinding>& constants);
 
-    void SetSamplers(std::span<TextureSampler> newSamplers);
+    void SetSamplers(std::span<const TextureSampler> newSamplers);
     std::span<const TextureSampler> GetStaticSamplers() const;
 
     std::span<const byte> GetLocalConstantsData() const;

--- a/src/Vex/CommandContext.h
+++ b/src/Vex/CommandContext.h
@@ -27,8 +27,6 @@ struct Texture;
 struct Buffer;
 struct TextureClearValue;
 struct DrawDescription;
-struct DrawResources;
-struct ComputeResources;
 struct RayTracingPassDescription;
 
 class CommandContext

--- a/src/Vex/GfxBackend.cpp
+++ b/src/Vex/GfxBackend.cpp
@@ -191,6 +191,13 @@ CommandContext GfxBackend::BeginScopedCommandContext(CommandQueueType queueType,
                                                      SubmissionPolicy submissionPolicy,
                                                      std::span<SyncToken> dependencies)
 {
+    if (submissionPolicy == SubmissionPolicy::DeferToPresent && !description.useSwapChain)
+    {
+        VEX_LOG(Fatal,
+                "Cannot use deferred submission policy when your graphics backend has no swapchain. Use "
+                "SubmissionPolicy::Immediate instead!");
+    }
+
     return CommandContext{ *this, commandPool->GetOrCreateCommandList(queueType), submissionPolicy, dependencies };
 }
 
@@ -467,7 +474,7 @@ void GfxBackend::SetShaderCompilationErrorsCallback(std::function<ShaderCompileE
     }
 }
 
-void GfxBackend::SetSamplers(std::span<TextureSampler> newSamplers)
+void GfxBackend::SetSamplers(std::span<const TextureSampler> newSamplers)
 {
     psCache->GetResourceLayout().SetSamplers(newSamplers);
 }

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -113,7 +113,7 @@ public:
     void RecompileAllShaders();
     void SetShaderCompilationErrorsCallback(std::function<ShaderCompileErrorsCallback> callback);
 
-    void SetSamplers(std::span<TextureSampler> newSamplers);
+    void SetSamplers(std::span<const TextureSampler> newSamplers);
 
     // Register a custom RenderExtension, it will be automatically unregistered when the graphics backend is destroyed.
     RenderExtension* RegisterRenderExtension(UniqueHandle<RenderExtension>&& renderExtension);

--- a/src/Vex/Resource.h
+++ b/src/Vex/Resource.h
@@ -2,6 +2,7 @@
 
 #include <span>
 
+#include <Vex/Concepts.h>
 #include <Vex/Handle.h>
 #include <Vex/Types.h>
 
@@ -58,6 +59,7 @@ public:
     void SetData(std::span<byte> inData, u32 offset);
 
     template <class T>
+        requires(not IsContainer<T>)
     void SetData(const T& inData);
 
 private:
@@ -69,10 +71,11 @@ private:
 };
 
 template <class T>
+    requires(not IsContainer<T>)
 void ResourceMappedMemory::SetData(const T& inData)
 {
     const u8* dataPtr = reinterpret_cast<const u8*>(&inData);
-    SetData(std::span{ dataPtr, sizeof(T) });
+    SetData(std::as_bytes(std::span{ dataPtr, sizeof(T) }));
 }
 
 } // namespace vex

--- a/src/Vex/TextureSampler.h
+++ b/src/Vex/TextureSampler.h
@@ -36,9 +36,9 @@ enum class BorderColor : u8
 
 struct TextureSampler
 {
-    FilterMode minFilter = FilterMode::Linear;
-    FilterMode magFilter = FilterMode::Linear;
-    FilterMode mipFilter = FilterMode::Linear;
+    FilterMode minFilter = FilterMode::Point;
+    FilterMode magFilter = FilterMode::Point;
+    FilterMode mipFilter = FilterMode::Point;
     AddressMode addressU = AddressMode::Wrap;
     AddressMode addressV = AddressMode::Wrap;
     AddressMode addressW = AddressMode::Wrap;
@@ -48,6 +48,23 @@ struct TextureSampler
     BorderColor borderColor = BorderColor::TransparentBlackFloat;
     float minLOD = 0.0f;
     float maxLOD = std::numeric_limits<float>::max();
+
+    static constexpr TextureSampler CreateSampler(FilterMode filterMode,
+                                                  AddressMode addressMode,
+                                                  float mipLODBias = 0.0f,
+                                                  u32 maxAnisotropy = 1)
+    {
+        return {
+            .minFilter = filterMode,
+            .magFilter = filterMode,
+            .mipFilter = filterMode,
+            .addressU = addressMode,
+            .addressV = addressMode,
+            .addressW = addressMode,
+            .mipLODBias = mipLODBias,
+            .maxAnisotropy = maxAnisotropy,
+        };
+    }
 };
 
 } // namespace vex

--- a/src/Vulkan/RHI/VkDescriptorSet.cpp
+++ b/src/Vulkan/RHI/VkDescriptorSet.cpp
@@ -2,14 +2,13 @@
 
 #include <Vex/Formattable.h>
 #include <Vex/PhysicalDevice.h>
+#include <Vex/Validation.h>
 
 #include <RHI/RHIDescriptorPool.h>
 
 #include <Vulkan/VkDebug.h>
 #include <Vulkan/VkErrorHandler.h>
 #include <Vulkan/VkGPUContext.h>
-
-#include <Vex/Validation.h>
 
 namespace vex::vk
 {

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -44,10 +44,10 @@ void VkGraphicsPipelineState::Compile(const Shader& vertexShader,
 
     std::array stages{ ::vk::PipelineShaderStageCreateInfo{ .stage = ::vk::ShaderStageFlagBits::eVertex,
                                                             .module = *vsShaderModule,
-                                                            .pName = "VSMain" },
+                                                            .pName = key.vertexShader.entryPoint.c_str() },
                        ::vk::PipelineShaderStageCreateInfo{ .stage = ::vk::ShaderStageFlagBits::eFragment,
                                                             .module = *psShaderModule,
-                                                            .pName = "PSMain" } };
+                                                            .pName = key.pixelShader.entryPoint.c_str() } };
 
     std::vector<::vk::VertexInputBindingDescription> bindings{ key.vertexInputLayout.bindings.size() };
     // Requires including the heavy <algorithm>
@@ -230,7 +230,7 @@ void VkComputePipelineState::Compile(const Shader& computeShader, RHIResourceLay
             ::vk::PipelineShaderStageCreateInfo{
                 .stage = ::vk::ShaderStageFlagBits::eCompute,
                 .module = *computeShaderModule,
-                .pName = "CSMain",
+                .pName = key.computeShader.entryPoint.c_str(),
             },
         .layout = *resourceLayout.pipelineLayout,
     };

--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -256,6 +256,7 @@ void VkRHI::Init(const UniqueHandle<PhysicalDevice>& vexPhysicalDevice)
     features12.timelineSemaphore = true;
     features12.descriptorIndexing = true;
     features12.runtimeDescriptorArray = true;
+    features12.shaderSampledImageArrayNonUniformIndexing = true;
     features12.descriptorBindingPartiallyBound = true;
     features12.descriptorBindingUniformBufferUpdateAfterBind = true;
     features12.descriptorBindingStorageBufferUpdateAfterBind = true;


### PR DESCRIPTION
- Texture Sampler can now take in a non-mutable TextureSampler span
- Added helper to construct TextureSampler
- Fixed Vulkan not taking into account the entrypoint for PSO creation.
- Some additional error handling.
- Fixed multi-RTV output not working in DX12
- Fixed issue with DX12 DepthStencil having both DepthStencil AND SRV usage.