### PR TITLE
DX12 Fixes

### DIFF
--- a/src/DX12/DX12DescriptorHeap.h
+++ b/src/DX12/DX12DescriptorHeap.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <format>
+
+#include <magic_enum/magic_enum.hpp>
+
 #include <Vex/Debug.h>
+#include <Vex/Platform/Platform.h>
 #include <Vex/Types.h>
 
 #include <DX12/DX12Headers.h>
@@ -31,7 +36,7 @@ class DX12DescriptorHeap
 
 public:
     DX12DescriptorHeap() = default;
-    DX12DescriptorHeap(ComPtr<DX12Device>& device, u32 heapSize)
+    DX12DescriptorHeap(ComPtr<DX12Device>& device, u32 heapSize, const std::string& name)
         : size{ heapSize }
     {
         // These are in this constructor because there is a small compilation speed gain when not directly in a
@@ -47,6 +52,13 @@ public:
         chk << device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&heap));
 
         descriptorByteSize = device->GetDescriptorHandleIncrementSize(static_cast<D3D12_DESCRIPTOR_HEAP_TYPE>(Type));
+#if !VEX_SHIPPING
+        chk << heap->SetName(StringToWString(std::format("DescriptorHeap: {} {} ({})",
+                                                         name,
+                                                         magic_enum::enum_name(Type),
+                                                         magic_enum::enum_name(Flags)))
+                                 .c_str());
+#endif
     }
 
     CD3DX12_CPU_DESCRIPTOR_HANDLE GetCPUDescriptorHandle(u32 index) const

--- a/src/DX12/RHI/DX12Buffer.cpp
+++ b/src/DX12/RHI/DX12Buffer.cpp
@@ -54,7 +54,7 @@ DX12Buffer::DX12Buffer(ComPtr<DX12Device>& device, RHIAllocator& allocator, cons
 #endif
 
 #if !VEX_SHIPPING
-    chk << buffer->SetName(StringToWString(desc.name).data());
+    chk << buffer->SetName(StringToWString(std::format("Buffer: {}", desc.name)).data());
 #endif
 }
 
@@ -135,7 +135,7 @@ BindlessHandle DX12Buffer::GetOrCreateBindlessView(BufferBindingUsage usage,
     {
         D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc{};
         cbvDesc.BufferLocation = buffer->GetGPUVirtualAddress();
-        cbvDesc.SizeInBytes = AlignUp<u32>(desc.byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+        cbvDesc.SizeInBytes = AlignUp<u64>(desc.byteSize, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
 
         device->CreateConstantBufferView(&cbvDesc, cpuHandle);
     }

--- a/src/DX12/RHI/DX12CommandPool.cpp
+++ b/src/DX12/RHI/DX12CommandPool.cpp
@@ -4,7 +4,10 @@
 
 #include <Vex/Debug.h>
 #include <Vex/Logger.h>
+#include <Vex/Platform/Platform.h>
 #include <Vex/RHIImpl/RHI.h>
+
+#include <DX12/HRChecker.h>
 
 namespace vex::dx12
 {
@@ -34,6 +37,11 @@ NonNullPtr<RHICommandList> DX12CommandPool::GetOrCreateCommandList(CommandQueueT
         // No more available command lists, create and return a new one.
         pool.push_back(MakeUnique<DX12CommandList>(device, queueType));
         cmdListPtr = pool.back().get();
+#if !VEX_SHIPPING
+        chk << cmdListPtr->GetNativeCommandList()->SetName(
+            StringToWString(std::format("CommandList: {}_{}", magic_enum::enum_name(queueType), pool.size() - 1))
+                .c_str());
+#endif
         VEX_LOG(Verbose, "Created new commandlist for queue {}", magic_enum::enum_name(queueType));
     }
 

--- a/src/DX12/RHI/DX12DescriptorPool.cpp
+++ b/src/DX12/RHI/DX12DescriptorPool.cpp
@@ -6,8 +6,8 @@ namespace vex::dx12
 DX12DescriptorPool::DX12DescriptorPool(ComPtr<DX12Device>& device)
     // TODO: allow resizing, currently disallowed
     : device{ device }
-    , gpuHeap(device, GDefaultDescriptorPoolSize)
-    , nullHeap(device, 1)
+    , gpuHeap(device, GDefaultDescriptorPoolSize, "DescriptorPool Heap")
+    , nullHeap(device, 1, "NullDescriptor Heap")
 {
     // Fill in the null heap with a null SRV.
     D3D12_SHADER_RESOURCE_VIEW_DESC nullDesc = {};

--- a/src/DX12/RHI/DX12PipelineState.cpp
+++ b/src/DX12/RHI/DX12PipelineState.cpp
@@ -63,7 +63,7 @@ void DX12GraphicsPipelineState::Compile(const Shader& vertexShader,
     pixelShaderVersion = pixelShader.version;
 
 #if !VEX_SHIPPING
-    chk << graphicsPSO->SetName(StringToWString(std::format("{}", key)).c_str());
+    chk << graphicsPSO->SetName(StringToWString(std::format("GraphicsPSO: {}", key)).c_str());
 #endif
 }
 
@@ -115,6 +115,10 @@ void DX12ComputePipelineState::Compile(const Shader& computeShader, RHIResourceL
     // Update versions for staleness purposes.
     rootSignatureVersion = resourceLayout.version;
     computeShaderVersion = computeShader.version;
+
+#if !VEX_SHIPPING
+    chk << computePSO->SetName(StringToWString(std::format("ComputePSO: {}", key)).c_str());
+#endif
 }
 
 void DX12ComputePipelineState::Cleanup(ResourceCleanup& resourceCleanup)

--- a/src/DX12/RHI/DX12RHI.cpp
+++ b/src/DX12/RHI/DX12RHI.cpp
@@ -110,6 +110,9 @@ void DX12RHI::Init(const UniqueHandle<PhysicalDevice>& physicalDevice)
                                        .Flags = D3D12_COMMAND_QUEUE_FLAG_NONE,
                                        .NodeMask = 0 };
         chk << device->CreateCommandQueue(&desc, IID_PPV_ARGS(&GetNativeQueue(CommandQueueType::Graphics)));
+#if !VEX_SHIPPING
+        GetNativeQueue(CommandQueueType::Graphics)->SetName(L"CommandQueue: Graphics");
+#endif
     }
 
     {
@@ -118,6 +121,9 @@ void DX12RHI::Init(const UniqueHandle<PhysicalDevice>& physicalDevice)
                                        .Flags = D3D12_COMMAND_QUEUE_FLAG_NONE,
                                        .NodeMask = 0 };
         chk << device->CreateCommandQueue(&desc, IID_PPV_ARGS(&GetNativeQueue(CommandQueueType::Compute)));
+#if !VEX_SHIPPING
+        GetNativeQueue(CommandQueueType::Graphics)->SetName(L"CommandQueue: Compute");
+#endif
     }
 
     {
@@ -126,6 +132,9 @@ void DX12RHI::Init(const UniqueHandle<PhysicalDevice>& physicalDevice)
                                        .Flags = D3D12_COMMAND_QUEUE_FLAG_NONE,
                                        .NodeMask = 0 };
         chk << device->CreateCommandQueue(&desc, IID_PPV_ARGS(&GetNativeQueue(CommandQueueType::Copy)));
+#if !VEX_SHIPPING
+        GetNativeQueue(CommandQueueType::Graphics)->SetName(L"CommandQueue: Copy");
+#endif
     }
 
     fences = DX12RHI_Internal::CreateFences(device);

--- a/src/DX12/RHI/DX12Texture.h
+++ b/src/DX12/RHI/DX12Texture.h
@@ -93,15 +93,16 @@ private:
 
     std::unordered_map<DX12TextureView, CacheEntry> viewCache;
 
-    static constexpr u32 MaxViewCountPerHeap = 8;
+    static constexpr u32 MaxViewCountPerRTVHeap = 8;
+    static constexpr u32 MaxViewCountPerDSVHeap = 4;
 
     // CPU-only visible heaps are "free" to create.
     // Aka they are just CPU memory, requiring no GPU calls.
     DX12DescriptorHeap<DX12HeapType::RTV> rtvHeap;
     DX12DescriptorHeap<DX12HeapType::DSV> dsvHeap;
 
-    FreeListAllocator rtvHeapAllocator{ MaxViewCountPerHeap };
-    FreeListAllocator dsvHeapAllocator{ MaxViewCountPerHeap };
+    FreeListAllocator rtvHeapAllocator;
+    FreeListAllocator dsvHeapAllocator;
 
     // Can be nullopt in the case of swapchain backbuffers.
     std::optional<Allocation> allocation;

--- a/src/RHI/RHIAllocator.cpp
+++ b/src/RHI/RHIAllocator.cpp
@@ -141,7 +141,11 @@ void RHIAllocatorBase::Free(const Allocation& allocation)
     auto& memoryPages = pageInfos[allocation.memoryTypeIndex];
     auto& page = memoryPages[allocation.pageHandle];
 #if !VEX_SHIPPING
-    VEX_LOG(Verbose, "Freed range: size {} offset {}", allocation.memoryRange.size, allocation.memoryRange.offset);
+    VEX_LOG(Verbose,
+            "Freed range: size {} offset {} type {}",
+            allocation.memoryRange.size,
+            allocation.memoryRange.offset,
+            allocation.memoryTypeIndex);
 #endif
     page.Free(allocation.memoryRange);
 

--- a/src/Vex/Handle.h
+++ b/src/Vex/Handle.h
@@ -14,29 +14,33 @@ struct Handle
     // 255).
     u32 value = ~0U;
 
-    static Derived CreateHandle(u32 index, u8 generation)
+    constexpr static Derived CreateHandle(u32 index, u8 generation)
     {
         Derived handle;
         handle.SetHandle(index, generation);
         return handle;
     }
-    void SetHandle(u32 index, u8 generation)
+    constexpr void SetHandle(u32 index, u8 generation)
     {
         value = 0;
         value |= (index & 0x00FFFFFF);
         value |= static_cast<u32>(generation) << 24;
     }
-    u32 GetIndex() const
+    constexpr u32 GetIndex() const
     {
         return value & 0x00FFFFFF;
     }
-    u8 GetGeneration() const
+    constexpr u8 GetGeneration() const
     {
         return value >> 24;
     }
     constexpr bool operator==(Handle other) const
     {
         return value == other.value;
+    }
+    constexpr bool IsValid() const
+    {
+        return value != ~0;
     }
 };
 


### PR DESCRIPTION
- Added more naming to dx12 objects
- RTV and DSV heaps are no longer always created for textures saving the API overhead