### PR TITLE
Unused Present Fix + Buffer Description Helpers

### DIFF
--- a/examples/hello_cube/HelloCube.cpp
+++ b/examples/hello_cube/HelloCube.cpp
@@ -31,34 +31,26 @@ HelloCubeApplication::HelloCubeApplication()
     SetupShaderErrorHandling();
 
     // Depth texture
-    depthTexture = graphics->CreateTexture(
-        {
-            .name = "Depth Texture",
-            .type = vex::TextureType::Texture2D,
-            .format = vex::TextureFormat::D32_FLOAT,
-            .width = static_cast<vex::u32>(width),
-            .height = static_cast<vex::u32>(height),
-            .usage = vex::TextureUsage::DepthStencil,
-            .clearValue =
-                vex::TextureClearValue{
-                    .flags = vex::TextureClear::ClearDepth,
-                    .depth = 0,
-                },
-        },
-        vex::ResourceLifetime::Static);
+    depthTexture = graphics->CreateTexture({
+        .name = "Depth Texture",
+        .type = vex::TextureType::Texture2D,
+        .format = vex::TextureFormat::D32_FLOAT,
+        .width = static_cast<vex::u32>(width),
+        .height = static_cast<vex::u32>(height),
+        .usage = vex::TextureUsage::DepthStencil,
+        .clearValue =
+            vex::TextureClearValue{
+                .flags = vex::TextureClear::ClearDepth,
+                .depth = 0,
+            },
+    });
 
     // Vertex buffer
-    vertexBuffer = graphics->CreateBuffer({ .name = "Vertex Buffer",
-                                            .byteSize = sizeof(Vertex) * VertexCount,
-                                            .usage = vex::BufferUsage::VertexBuffer,
-                                            .memoryLocality = vex::ResourceMemoryLocality::GPUOnly },
-                                          vex::ResourceLifetime::Static);
+    vertexBuffer = graphics->CreateBuffer(
+        vex::BufferDescription::CreateVertexBufferDesc("Vertex Buffer", sizeof(Vertex) * VertexCount));
     // Index buffer
-    indexBuffer = graphics->CreateBuffer({ .name = "Index Buffer",
-                                           .byteSize = sizeof(vex::u32) * IndexCount,
-                                           .usage = vex::BufferUsage::IndexBuffer,
-                                           .memoryLocality = vex::ResourceMemoryLocality::GPUOnly },
-                                         vex::ResourceLifetime::Static);
+    indexBuffer = graphics->CreateBuffer(
+        vex::BufferDescription::CreateIndexBufferDesc("Index Buffer", sizeof(vex::u32) * IndexCount));
 
     {
         // Immediate submission means the commands are instantly submitted upon destruction.
@@ -121,8 +113,7 @@ HelloCubeApplication::HelloCubeApplication()
                                       .height = static_cast<vex::u32>(height),
                                       .depthOrArraySize = 1,
                                       .mips = 0, // 0 means max mips (down to 1x1)
-                                      .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite },
-                                    vex::ResourceLifetime::Static);
+                                      .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
 
         // Upload only to the first mip
         ctx.EnqueueDataUpload(
@@ -300,19 +291,17 @@ void HelloCubeApplication::OnResize(GLFWwindow* window, uint32_t width, uint32_t
 
     ExampleApplication::OnResize(window, width, height);
 
-    depthTexture = graphics->CreateTexture(
-        {
-            .name = "Depth Texture",
-            .type = vex::TextureType::Texture2D,
-            .format = vex::TextureFormat::D32_FLOAT,
-            .width = static_cast<vex::u32>(width),
-            .height = static_cast<vex::u32>(height),
-            .usage = vex::TextureUsage::DepthStencil,
-            .clearValue =
-                vex::TextureClearValue{
-                    .flags = vex::TextureClear::ClearDepth,
-                    .depth = 0,
-                },
-        },
-        vex::ResourceLifetime::Static);
+    depthTexture = graphics->CreateTexture({
+        .name = "Depth Texture",
+        .type = vex::TextureType::Texture2D,
+        .format = vex::TextureFormat::D32_FLOAT,
+        .width = static_cast<vex::u32>(width),
+        .height = static_cast<vex::u32>(height),
+        .usage = vex::TextureUsage::DepthStencil,
+        .clearValue =
+            vex::TextureClearValue{
+                .flags = vex::TextureClear::ClearDepth,
+                .depth = 0,
+            },
+    });
 }

--- a/examples/hello_raytracing/HelloRayTracing.cpp
+++ b/examples/hello_raytracing/HelloRayTracing.cpp
@@ -28,8 +28,7 @@ HelloRayTracing::HelloRayTracing()
                                   .height = DefaultHeight,
                                   .depthOrArraySize = 1,
                                   .mips = 1,
-                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite },
-                                vex::ResourceLifetime::Static);
+                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
 }
 
 void HelloRayTracing::Run()
@@ -97,16 +96,14 @@ void HelloRayTracing::OnResize(GLFWwindow* window, uint32_t newWidth, uint32_t n
 
     ExampleApplication::OnResize(window, newWidth, newHeight);
 
-    workingTexture = graphics->CreateTexture(
-        {
-            .name = "Working Texture",
-            .type = vex::TextureType::Texture2D,
-            .format = vex::TextureFormat::RGBA8_UNORM,
-            .width = newWidth,
-            .height = newHeight,
-            .depthOrArraySize = 1,
-            .mips = 1,
-            .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite,
-        },
-        vex::ResourceLifetime::Static);
+    workingTexture = graphics->CreateTexture({
+        .name = "Working Texture",
+        .type = vex::TextureType::Texture2D,
+        .format = vex::TextureFormat::RGBA8_UNORM,
+        .width = newWidth,
+        .height = newHeight,
+        .depthOrArraySize = 1,
+        .mips = 1,
+        .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite,
+    });
 }

--- a/examples/hello_triangle/HelloTriangleApplication.cpp
+++ b/examples/hello_triangle/HelloTriangleApplication.cpp
@@ -28,8 +28,7 @@ HelloTriangleApplication::HelloTriangleApplication()
                                   .height = DefaultHeight,
                                   .depthOrArraySize = 1,
                                   .mips = 1,
-                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite },
-                                vex::ResourceLifetime::Static);
+                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
     finalOutputTexture =
         graphics->CreateTexture({ .name = "Final Output Texture",
                                   .type = vex::TextureType::Texture2D,
@@ -38,22 +37,19 @@ HelloTriangleApplication::HelloTriangleApplication()
                                   .height = DefaultHeight,
                                   .depthOrArraySize = 1,
                                   .mips = 1,
-                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite },
-                                vex::ResourceLifetime::Static);
+                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
 
     // Example of CPU accessible buffer
     colorBuffer = graphics->CreateBuffer({ .name = "Color Buffer",
                                            .byteSize = sizeof(float) * 4,
                                            .usage = vex::BufferUsage::UniformBuffer,
-                                           .memoryLocality = vex::ResourceMemoryLocality::GPUOnly },
-                                         vex::ResourceLifetime::Static);
+                                           .memoryLocality = vex::ResourceMemoryLocality::GPUOnly });
 
     // Example of GPU only buffer
     commBuffer = graphics->CreateBuffer({ .name = "Comm Buffer",
                                           .byteSize = sizeof(float) * 4,
                                           .usage = vex::BufferUsage::ReadWriteBuffer | vex::BufferUsage::GenericBuffer,
-                                          .memoryLocality = vex::ResourceMemoryLocality::GPUOnly },
-                                        vex::ResourceLifetime::Static);
+                                          .memoryLocality = vex::ResourceMemoryLocality::GPUOnly });
 }
 
 void HelloTriangleApplication::Run()
@@ -201,18 +197,14 @@ void HelloTriangleApplication::OnResize(GLFWwindow* window, uint32_t newWidth, u
                                   .height = newHeight,
                                   .depthOrArraySize = 1,
                                   .mips = 1,
-                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite },
-                                vex::ResourceLifetime::Static);
-    workingTexture = graphics->CreateTexture(
-        {
-            .name = "Working Texture",
-            .type = vex::TextureType::Texture2D,
-            .format = vex::TextureFormat::RGBA8_UNORM,
-            .width = newWidth,
-            .height = newHeight,
-            .depthOrArraySize = 1,
-            .mips = 1,
-            .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite,
-        },
-        vex::ResourceLifetime::Static);
+                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
+    workingTexture =
+        graphics->CreateTexture({ .name = "Working Texture",
+                                  .type = vex::TextureType::Texture2D,
+                                  .format = vex::TextureFormat::RGBA8_UNORM,
+                                  .width = newWidth,
+                                  .height = newHeight,
+                                  .depthOrArraySize = 1,
+                                  .mips = 1,
+                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
 }

--- a/examples/hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
+++ b/examples/hello_triangle_graphics_pipeline/HelloTriangleGraphicsApplication.cpp
@@ -22,8 +22,7 @@ HelloTriangleGraphicsApplication::HelloTriangleGraphicsApplication()
     colorBuffer = graphics->CreateBuffer({ .name = "Color Buffer",
                                            .byteSize = sizeof(float) * 4,
                                            .usage = vex::BufferUsage::UniformBuffer,
-                                           .memoryLocality = vex::ResourceMemoryLocality::GPUOnly },
-                                         vex::ResourceLifetime::Static);
+                                           .memoryLocality = vex::ResourceMemoryLocality::GPUOnly });
 
     // Working texture we'll fill in then copy to the backbuffer.
     workingTexture =
@@ -34,8 +33,7 @@ HelloTriangleGraphicsApplication::HelloTriangleGraphicsApplication()
                                   .height = DefaultHeight,
                                   .depthOrArraySize = 1,
                                   .mips = 1,
-                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite },
-                                vex::ResourceLifetime::Static);
+                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
 }
 
 void HelloTriangleGraphicsApplication::Run()
@@ -155,6 +153,5 @@ void HelloTriangleGraphicsApplication::OnResize(GLFWwindow* window, uint32_t wid
                                   .height = height,
                                   .depthOrArraySize = 1,
                                   .mips = 1,
-                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite },
-                                vex::ResourceLifetime::Static);
+                                  .usage = vex::TextureUsage::ShaderRead | vex::TextureUsage::ShaderReadWrite });
 }

--- a/src/Tests/TextureUpload.cpp
+++ b/src/Tests/TextureUpload.cpp
@@ -14,9 +14,11 @@ void TestTextureUpload(NonNullPtr<GfxBackend> graphics, CommandQueueType type)
 
         u32 cubemapFaceSize = 16;
         u16 cubemapMips = 2;
-        Texture cubemapTexture = graphics->CreateTexture(
-            TextureDescription::CreateTextureCube("Cubemap", TextureFormat::RGBA8_UNORM, cubemapFaceSize, cubemapMips),
-            ResourceLifetime::Static);
+        Texture cubemapTexture =
+            graphics->CreateTexture(TextureDescription::CreateTextureCubeDesc("Cubemap",
+                                                                              TextureFormat::RGBA8_UNORM,
+                                                                              cubemapFaceSize,
+                                                                              cubemapMips));
 
         std::vector<u8> cubemapData;
         cubemapData.reserve(cubemapFaceSize * cubemapFaceSize * GTextureCubeFaceCount * 4 * cubemapMips);
@@ -62,13 +64,13 @@ void TestTextureUpload(NonNullPtr<GfxBackend> graphics, CommandQueueType type)
 
         u32 width = 16, height = 12, arraySize = 2;
         u16 mips = 3;
-        Texture texture = graphics->CreateTexture(TextureDescription::CreateTexture2DArray("2dTextureArray",
-                                                                                           TextureFormat::RGBA8_UNORM,
-                                                                                           width,
-                                                                                           height,
-                                                                                           arraySize,
-                                                                                           mips),
-                                                  ResourceLifetime::Static);
+        Texture texture =
+            graphics->CreateTexture(TextureDescription::CreateTexture2DArrayDesc("2dTextureArray",
+                                                                                 TextureFormat::RGBA8_UNORM,
+                                                                                 width,
+                                                                                 height,
+                                                                                 arraySize,
+                                                                                 mips));
 
         std::vector<u8> data;
         data.reserve(width * height * arraySize * 4 * mips);
@@ -131,12 +133,11 @@ void TestTextureUpload(NonNullPtr<GfxBackend> graphics, CommandQueueType type)
         u16 cubemapMips = 2;
         u16 cubemapArraySize = 3;
         Texture cubemapTexture =
-            graphics->CreateTexture(TextureDescription::CreateTextureCubeArray("CubemapArray",
-                                                                               TextureFormat::RGBA8_UNORM,
-                                                                               cubemapFaceSize,
-                                                                               cubemapArraySize,
-                                                                               cubemapMips),
-                                    ResourceLifetime::Static);
+            graphics->CreateTexture(TextureDescription::CreateTextureCubeArrayDesc("CubemapArray",
+                                                                                   TextureFormat::RGBA8_UNORM,
+                                                                                   cubemapFaceSize,
+                                                                                   cubemapArraySize,
+                                                                                   cubemapMips));
 
         std::vector<u8> cubemapData;
         cubemapData.reserve(cubemapFaceSize * cubemapFaceSize * GTextureCubeFaceCount * cubemapArraySize * 4 *
@@ -190,9 +191,12 @@ void TestTextureUpload(NonNullPtr<GfxBackend> graphics, CommandQueueType type)
         // Cursed non-even sizes.
         u32 width = 121, height = 165, depth = 64;
         u16 mips = 3;
-        Texture texture = graphics->CreateTexture(
-            TextureDescription::CreateTexture3D("3DTexture", TextureFormat::RGBA8_UNORM, width, height, depth, mips),
-            ResourceLifetime::Static);
+        Texture texture = graphics->CreateTexture(TextureDescription::CreateTexture3DDesc("3DTexture",
+                                                                                          TextureFormat::RGBA8_UNORM,
+                                                                                          width,
+                                                                                          height,
+                                                                                          depth,
+                                                                                          mips));
 
         std::vector<u8> data;
         data.reserve(width * height * depth * 4 * mips);

--- a/src/Vex/Buffer.cpp
+++ b/src/Vex/Buffer.cpp
@@ -39,4 +39,68 @@ void ValidateSimpleBufferCopy(const BufferDescription& srcDesc, const BufferDesc
 
 } // namespace BufferUtil
 
+BufferDescription BufferDescription::CreateUniformBufferDesc(std::string name, u64 byteSize)
+{
+    return {
+        .name = std::move(name),
+        .byteSize = byteSize,
+        .usage = BufferUsage::UniformBuffer,
+        .memoryLocality = ResourceMemoryLocality::CPUWrite,
+    };
+}
+
+BufferDescription BufferDescription::CreateVertexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead)
+{
+    BufferUsage::Flags usageFlags = BufferUsage::VertexBuffer;
+    if (allowShaderRead)
+    {
+        usageFlags |= BufferUsage::GenericBuffer;
+    }
+    return {
+        .name = std::move(name),
+        .byteSize = byteSize,
+        .usage = usageFlags,
+        .memoryLocality = ResourceMemoryLocality::GPUOnly,
+    };
+}
+
+BufferDescription BufferDescription::CreateIndexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead)
+{
+    BufferUsage::Flags usageFlags = BufferUsage::IndexBuffer;
+    if (allowShaderRead)
+    {
+        usageFlags |= BufferUsage::GenericBuffer;
+    }
+    return {
+        .name = std::move(name),
+        .byteSize = byteSize,
+        .usage = usageFlags,
+        .memoryLocality = ResourceMemoryLocality::GPUOnly,
+    };
+}
+
+BufferDescription BufferDescription::CreateStagingBufferDesc(std::string name,
+                                                             u64 byteSize,
+                                                             BufferUsage::Flags usageFlags)
+{
+    return {
+        .name = std::move(name),
+        .byteSize = byteSize,
+        .usage = usageFlags,
+        .memoryLocality = ResourceMemoryLocality::CPUWrite,
+    };
+}
+
+BufferDescription BufferDescription::CreateReadbackBufferDesc(std::string name,
+                                                              u64 byteSize,
+                                                              BufferUsage::Flags usageFlags)
+{
+    return {
+        .name = std::move(name),
+        .byteSize = byteSize,
+        .usage = usageFlags,
+        .memoryLocality = ResourceMemoryLocality::CPURead,
+    };
+}
+
 } // namespace vex

--- a/src/Vex/Buffer.h
+++ b/src/Vex/Buffer.h
@@ -17,7 +17,7 @@ namespace vex
 BEGIN_VEX_ENUM_FLAGS(BufferUsage, u8)
     None                            = 0,      // Buffers that will never be bound anywhere. Mostly used for staging buffers.
     GenericBuffer                   = 1 << 0, // Buffers that can be read from shaders (SRV)
-    UniformBuffer                   = 1 << 1, // Buffers with specific alignment constraints (CBV)
+    UniformBuffer                   = 1 << 1, // Buffers with specific alignment constraints uniformly read across waves (CBV)
     ReadWriteBuffer                 = 1 << 2, // Buffers with read and write operations in shaders (UAV)
     VertexBuffer                    = 1 << 3, // Buffers used for vertex buffers
     IndexBuffer                     = 1 << 4, // Buffers used for index buffers
@@ -27,9 +27,8 @@ END_VEX_ENUM_FLAGS();
 
 // clang-format on
 
-// Defines what the specific binding will bind as
-// maps directly to the type that will be used in the
-// shader to access the buffer
+// Defines what the specific binding will bind as maps directly to the type that will be used in the shader to access
+// the buffer.
 enum class BufferBindingUsage : u8
 {
     ConstantBuffer,
@@ -67,6 +66,23 @@ struct BufferDescription
     u64 byteSize = 0;
     BufferUsage::Flags usage = BufferUsage::GenericBuffer;
     ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly;
+
+    // Helpers to create a buffer description.
+
+    // Creates a CPUWrite buffer useable as a Uniform (/constant) Buffer.
+    static BufferDescription CreateUniformBufferDesc(std::string name, u64 byteSize);
+    // Creates a GPUOnly buffer useable as an Vertex Buffer.
+    static BufferDescription CreateVertexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead = false);
+    // Creates a GPUOnly buffer useable as an Index Buffer.
+    static BufferDescription CreateIndexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead = false);
+    // Creates a CPUWrite staging buffer useful for uploading data to GPUOnly resources.
+    static BufferDescription CreateStagingBufferDesc(std::string name,
+                                                     u64 byteSize,
+                                                     BufferUsage::Flags usageFlags = BufferUsage::None);
+    // Creates a CPURead readback buffer, used for performing data readback from the GPU to the CPU.
+    static BufferDescription CreateReadbackBufferDesc(std::string name,
+                                                      u64 byteSize,
+                                                      BufferUsage::Flags usageFlags = BufferUsage::None);
 };
 
 // Strongly defined type represents a buffer.

--- a/src/Vex/GfxBackend.h
+++ b/src/Vex/GfxBackend.h
@@ -40,7 +40,10 @@ struct BackendDescription
     PlatformWindow platformWindow;
     bool useSwapChain = true;
     TextureFormat swapChainFormat;
+    // Clear value to use for present textures.
+    TextureClearValue presentTextureClearValue = { .flags = TextureClear::ClearColor, .color = { 0, 0, 0, 0 } };
     bool useVSync = false;
+    // Determines the minimum number of backbuffers the application will leverage at once.
     FrameBuffering frameBuffering = FrameBuffering::Triple;
     bool enableGPUDebugLayer = !VEX_SHIPPING;
     bool enableGPUBasedValidation = !VEX_SHIPPING;
@@ -65,10 +68,12 @@ public:
                                              std::span<SyncToken> dependencies = {});
 
     // Creates a new texture with the specified description.
-    [[nodiscard]] Texture CreateTexture(TextureDescription description, ResourceLifetime lifetime);
+    [[nodiscard]] Texture CreateTexture(TextureDescription description,
+                                        ResourceLifetime lifetime = ResourceLifetime::Static);
 
-    // Creates a new buffer with specified description.
-    [[nodiscard]] Buffer CreateBuffer(BufferDescription description, ResourceLifetime lifetime);
+    // Creates a new buffer with the specified description.
+    [[nodiscard]] Buffer CreateBuffer(BufferDescription description,
+                                      ResourceLifetime lifetime = ResourceLifetime::Static);
 
     // Writes data to buffer memory. This only supports buffers with ResourceMemoryLocality::CPUWrite.
     [[nodiscard]] ResourceMappedMemory MapResource(const Buffer& buffer);

--- a/src/Vex/Texture.cpp
+++ b/src/Vex/Texture.cpp
@@ -368,7 +368,7 @@ std::vector<TextureUploadRegion> TextureUploadRegion::UploadFullMip(u16 mipIndex
     return regions;
 }
 
-TextureDescription TextureDescription::CreateTexture2D(std::string name,
+TextureDescription TextureDescription::CreateTexture2DDesc(std::string name,
                                                        TextureFormat format,
                                                        u32 width,
                                                        u32 height,
@@ -392,7 +392,7 @@ TextureDescription TextureDescription::CreateTexture2D(std::string name,
     return description;
 }
 
-TextureDescription TextureDescription::CreateTexture2DArray(std::string name,
+TextureDescription TextureDescription::CreateTexture2DArrayDesc(std::string name,
                                                             TextureFormat format,
                                                             u32 width,
                                                             u32 height,
@@ -417,7 +417,7 @@ TextureDescription TextureDescription::CreateTexture2DArray(std::string name,
     return description;
 }
 
-TextureDescription TextureDescription::CreateTextureCube(std::string name,
+TextureDescription TextureDescription::CreateTextureCubeDesc(std::string name,
                                                          TextureFormat format,
                                                          u32 faceSize,
                                                          u16 mips,
@@ -440,7 +440,7 @@ TextureDescription TextureDescription::CreateTextureCube(std::string name,
     return description;
 }
 
-TextureDescription TextureDescription::CreateTextureCubeArray(std::string name,
+TextureDescription TextureDescription::CreateTextureCubeArrayDesc(std::string name,
                                                               TextureFormat format,
                                                               u32 faceSize,
                                                               u32 arraySize,
@@ -464,7 +464,7 @@ TextureDescription TextureDescription::CreateTextureCubeArray(std::string name,
     return description;
 }
 
-TextureDescription TextureDescription::CreateTexture3D(std::string name,
+TextureDescription TextureDescription::CreateTexture3DDesc(std::string name,
                                                        TextureFormat format,
                                                        u32 width,
                                                        u32 height,

--- a/src/Vex/Texture.h
+++ b/src/Vex/Texture.h
@@ -104,18 +104,19 @@ struct TextureDescription
         return arraySize;
     }
 
-    // Helpers to create a description.
+    // Helpers to create a texture description.
 
-    static TextureDescription CreateTexture2D(std::string name,
-                                              TextureFormat format,
-                                              u32 width,
-                                              u32 height,
-                                              u16 mips = 1,
-                                              TextureUsage::Flags usage = TextureUsage::ShaderRead,
-                                              TextureClearValue clearValue = {},
-                                              ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly);
+    static TextureDescription CreateTexture2DDesc(
+        std::string name,
+        TextureFormat format,
+        u32 width,
+        u32 height,
+        u16 mips = 1,
+        TextureUsage::Flags usage = TextureUsage::ShaderRead,
+        TextureClearValue clearValue = {},
+        ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly);
 
-    static TextureDescription CreateTexture2DArray(
+    static TextureDescription CreateTexture2DArrayDesc(
         std::string name,
         TextureFormat format,
         u32 width,
@@ -126,7 +127,7 @@ struct TextureDescription
         TextureClearValue clearValue = {},
         ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly);
 
-    static TextureDescription CreateTextureCube(
+    static TextureDescription CreateTextureCubeDesc(
         std::string name,
         TextureFormat format,
         u32 faceSize,
@@ -135,7 +136,7 @@ struct TextureDescription
         TextureClearValue clearValue = {},
         ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly);
 
-    static TextureDescription CreateTextureCubeArray(
+    static TextureDescription CreateTextureCubeArrayDesc(
         std::string name,
         TextureFormat format,
         u32 faceSize,
@@ -145,15 +146,16 @@ struct TextureDescription
         TextureClearValue clearValue = {},
         ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly);
 
-    static TextureDescription CreateTexture3D(std::string name,
-                                              TextureFormat format,
-                                              u32 width,
-                                              u32 height,
-                                              u32 depth,
-                                              u16 mips = 1,
-                                              TextureUsage::Flags usage = TextureUsage::ShaderRead,
-                                              TextureClearValue clearValue = {},
-                                              ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly);
+    static TextureDescription CreateTexture3DDesc(
+        std::string name,
+        TextureFormat format,
+        u32 width,
+        u32 height,
+        u32 depth,
+        u16 mips = 1,
+        TextureUsage::Flags usage = TextureUsage::ShaderRead,
+        TextureClearValue clearValue = {},
+        ResourceMemoryLocality memoryLocality = ResourceMemoryLocality::GPUOnly);
 };
 
 // Strongly defined type represents a texture.

--- a/tests/GraphicsTest.cpp
+++ b/tests/GraphicsTest.cpp
@@ -143,14 +143,14 @@ TEST(GraphicsTests, SynchronizationTortureTest)
             texDesc.height = 512;
             texDesc.format = TextureFormat::RGBA8_UNORM;
             texDesc.usage = TextureUsage::ShaderRead;
-            textures.push_back(graphics.CreateTexture(texDesc, ResourceLifetime::Static));
+            textures.push_back(graphics.CreateTexture(texDesc));
 
             BufferDescription bufDesc{};
             bufDesc.name = std::format("Test3 Buf_{}", i);
             bufDesc.byteSize = 1024 * 1024; // 1MB
             bufDesc.usage = BufferUsage::GenericBuffer;
             bufDesc.memoryLocality = ResourceMemoryLocality::GPUOnly;
-            buffers.push_back(graphics.CreateBuffer(bufDesc, ResourceLifetime::Static));
+            buffers.push_back(graphics.CreateBuffer(bufDesc));
 
             VEX_LOG(Verbose, "Created texture {} and buffer {}", i, i);
         }
@@ -298,7 +298,7 @@ TEST(GraphicsTests, SynchronizationTortureTest)
         uploadBufDesc.byteSize = 1024 * 1024; // 1MB
         uploadBufDesc.usage = BufferUsage::None;
         uploadBufDesc.memoryLocality = ResourceMemoryLocality::CPUWrite;
-        auto uploadBuffer = graphics.CreateBuffer(uploadBufDesc, ResourceLifetime::Static);
+        auto uploadBuffer = graphics.CreateBuffer(uploadBufDesc);
 
         // Create target texture
         TextureDescription texDesc{};
@@ -307,7 +307,7 @@ TEST(GraphicsTests, SynchronizationTortureTest)
         texDesc.height = 256;
         texDesc.format = TextureFormat::RGBA8_UNORM;
         texDesc.usage = TextureUsage::ShaderRead;
-        auto targetTexture = graphics.CreateTexture(texDesc, ResourceLifetime::Static);
+        auto targetTexture = graphics.CreateTexture(texDesc);
 
         std::vector<SyncToken> uploadTokens;
 
@@ -358,14 +358,14 @@ TEST(GraphicsTests, SynchronizationTortureTest)
             texDesc.height = 128;
             texDesc.format = TextureFormat::RGBA8_UNORM;
             texDesc.usage = TextureUsage::ShaderRead;
-            textures.push_back(graphics.CreateTexture(texDesc, ResourceLifetime::Static));
+            textures.push_back(graphics.CreateTexture(texDesc));
 
             BufferDescription bufDesc{};
             bufDesc.name = std::format("Test7 Buf_{}", i);
             bufDesc.byteSize = 64 * 1024;
             bufDesc.usage = BufferUsage::GenericBuffer;
             bufDesc.memoryLocality = ResourceMemoryLocality::GPUOnly;
-            buffers.push_back(graphics.CreateBuffer(bufDesc, ResourceLifetime::Static));
+            buffers.push_back(graphics.CreateBuffer(bufDesc));
         }
 
         // Chaotic submission pattern


### PR DESCRIPTION
- If the current present texture has never been used, it will now be cleared before being copied to the backbuffer to avoid displaying garbage data (this is valid behaviour for BOTH apis,  we never want to display garbage memory).
- Added some buffer desc helpers.
- Refactor to add a default param to CreateBuffer and CreateTexture methods.