### PR TITLE
Vulkan Ray Tracing

### DIFF
--- a/cmake/VexSlang.cmake
+++ b/cmake/VexSlang.cmake
@@ -7,7 +7,7 @@ if(NOT VEX_ENABLE_SLANG)
     return()
 endif()
 
-set(SLANG_VERSION "2026.3.1")
+set(SLANG_VERSION "2026.4.2")
 
 # Choose URLs based on platform
 if(WIN32)

--- a/cmake/VexVulkan.cmake
+++ b/cmake/VexVulkan.cmake
@@ -59,6 +59,8 @@ function(setup_vulkan_backend TARGET)
         "src/Vulkan/RHI/VkAccelerationStructure.cpp"
         "src/Vulkan/RHI/VkPhysicalDevice.h"
         "src/Vulkan/RHI/VkPhysicalDevice.cpp"
+        "src/Vulkan/RHI/VkShaderTable.cpp"
+        "src/Vulkan/RHI/VkShaderTable.h"
         # Vulkan API
         "src/Vulkan/VkGraphicsPipeline.h"
         "src/Vulkan/VkGraphicsPipeline.cpp"

--- a/examples/hello_raytracing/HelloRayTracing.cpp
+++ b/examples/hello_raytracing/HelloRayTracing.cpp
@@ -64,8 +64,8 @@ HelloRayTracing::HelloRayTracing()
 
     ctx.BuildBLAS(triangleBLAS,
                   { .geometry = { vex::BLASGeometryDesc{
-                        .vertexBufferBinding = { .buffer = vertexBuffer, .strideByteSize = static_cast<vex::u32>(sizeof(Vertex)), },
-                        .indexBufferBinding = vex::BufferBinding{ .buffer = indexBuffer, .strideByteSize = static_cast<vex::u32>(sizeof(vex::u32)), },
+                        .vertexBufferBinding = vex::BufferBinding::CreateStructuredBuffer(vertexBuffer, sizeof(Vertex)),
+                        .indexBufferBinding = vex::BufferBinding::CreateStructuredBuffer(indexBuffer, sizeof(vex::u32)),
                         .transform = std::nullopt,
                         .flags = vex::ASGeometry::Opaque,
                     } } });

--- a/examples/hello_raytracing/HelloRayTracing.cpp
+++ b/examples/hello_raytracing/HelloRayTracing.cpp
@@ -50,11 +50,13 @@ HelloRayTracing::HelloRayTracing()
 
     // Create vertex and index buffers
     const vex::BufferDesc vbDesc =
-        vex::BufferDesc::CreateVertexBufferDesc("RT Vertex Buffer", sizeof(Vertex) * TriangleVerts.size());
+        vex::BufferDesc::CreateVertexBufferDesc("RT Vertex Buffer", sizeof(Vertex) * TriangleVerts.size(), false, true);
     vex::Buffer vertexBuffer = graphics->CreateBuffer(vbDesc);
 
-    const vex::BufferDesc ibDesc =
-        vex::BufferDesc::CreateIndexBufferDesc("RT Index Buffer", sizeof(vex::u32) * TriangleIndices.size());
+    const vex::BufferDesc ibDesc = vex::BufferDesc::CreateIndexBufferDesc("RT Index Buffer",
+                                                                          sizeof(vex::u32) * TriangleIndices.size(),
+                                                                          false,
+                                                                          true);
     vex::Buffer indexBuffer = graphics->CreateBuffer(ibDesc);
 
     vex::CommandContext ctx = graphics->CreateCommandContext(vex::QueueType::Graphics);

--- a/examples/hello_raytracing/HelloRayTracingShader.hlsl
+++ b/examples/hello_raytracing/HelloRayTracingShader.hlsl
@@ -8,9 +8,6 @@ struct UniformStruct
 
 VEX_UNIFORMS(UniformStruct, Uniforms);
 
-static const RWTexture2D<float4> OutputTexture = GetBindlessResource(Uniforms.outputTextureHandle);
-static RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
-
 // We use the built-in HLSL HitAttributes.
 typedef BuiltInTriangleIntersectionAttributes HitAttributes;
 
@@ -22,6 +19,9 @@ struct [raypayload] RayPayload
 [shader("raygeneration")]
 void RayGenMain()
 {
+    RWTexture2D<float4> OutputTexture = GetBindlessResource(Uniforms.outputTextureHandle);
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+
     // Get the dispatch coordinates
     uint2 launchIndex = DispatchRaysIndex().xy;
     uint2 launchDimensions = DispatchRaysDimensions().xy;

--- a/src/DX12/RHI/DX12AccelerationStructure.h
+++ b/src/DX12/RHI/DX12AccelerationStructure.h
@@ -24,6 +24,9 @@ public:
     virtual const RHIAccelerationStructureBuildInfo& SetupTLASBuild(RHIAllocator& allocator,
                                                                     const RHITLASBuildDesc& desc) override;
 
+    virtual std::vector<std::byte> GetInstanceBufferData(const RHITLASBuildDesc& desc) override;
+    virtual u32 GetInstanceBufferStride() override;
+
 private:
     void InitRayTracingGeometryDesc(const RHIBLASBuildDesc& desc);
 

--- a/src/DX12/RHI/DX12Buffer.cpp
+++ b/src/DX12/RHI/DX12Buffer.cpp
@@ -160,7 +160,7 @@ void DX12Buffer::AllocateBindlessHandle(RHIDescriptorPool& descriptorPool,
     const bool isSRV = usage == BufferBindingUsage::StructuredBuffer || usage == BufferBindingUsage::ByteAddressBuffer;
     const bool isUAV =
         usage == BufferBindingUsage::RWStructuredBuffer || usage == BufferBindingUsage::RWByteAddressBuffer;
-    const bool isAccelerationStructure = desc.usage & BufferUsage::AccelerationStructure;
+    const bool isAccelerationStructure = viewDesc.isAccelerationStructure;
 
     VEX_ASSERT(isSRV || isUAV || isCBV || isAccelerationStructure,
                "The bindless view requested for buffer '{}' must be either of type SRV, CBV, UAV or the underlying "

--- a/src/DX12/RHI/DX12CommandList.cpp
+++ b/src/DX12/RHI/DX12CommandList.cpp
@@ -706,35 +706,12 @@ void DX12CommandList::BuildTLAS(RHIAccelerationStructure& as,
                                 const RHITLASBuildDesc& desc)
 {
     VEX_ASSERT(as.GetDesc().type == ASType::TopLevel, "Invalid Acceleration Structure type...");
-    // Upload required info into the upload buffer.
-    {
-        MappedMemory map{ uploadBuffer };
-        D3D12_RAYTRACING_INSTANCE_DESC* instanceDescs =
-            reinterpret_cast<D3D12_RAYTRACING_INSTANCE_DESC*>(map.GetMappedRange().data());
-        for (u32 instance = 0; instance < desc.instanceDescs.size(); ++instance)
-        {
-            const TLASInstanceDesc& tlasDesc = desc.instanceDescs[instance];
-            *instanceDescs = D3D12_RAYTRACING_INSTANCE_DESC{
-                .InstanceID = tlasDesc.instanceID,
-                .InstanceMask = tlasDesc.instanceMask,
-                .InstanceContributionToHitGroupIndex = tlasDesc.instanceContributionToHitGroupIndex,
-                .Flags = ASInstanceFlagsToDX12InstanceFlags(tlasDesc.instanceFlags),
-                .AccelerationStructure = desc.perInstanceBLAS[instance]->GetRHIBuffer().GetGPUVirtualAddress(),
-            };
-
-            std::memcpy(reinterpret_cast<float*>(instanceDescs->Transform),
-                        tlasDesc.transform.data(),
-                        tlasDesc.transform.size() * sizeof(float));
-
-            ++instanceDescs;
-        }
-    }
 
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc = {};
     buildDesc.Inputs = D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS{
         .Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL,
         .Flags = ASBuildFlagsToDX12ASBuildFlags(as.GetDesc().buildFlags),
-        .NumDescs = static_cast<u32>(desc.instanceDescs.size()),
+        .NumDescs = static_cast<u32>(desc.instances.size()),
         .DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY,
         .InstanceDescs = uploadBuffer.GetGPUVirtualAddress(),
     };

--- a/src/RHI/RHIAccelerationStructure.h
+++ b/src/RHI/RHIAccelerationStructure.h
@@ -20,7 +20,7 @@ struct RHIBLASGeometryDesc
     // For Triangles:
     std::optional<RHIBufferBinding> vertexBufferBinding;
     std::optional<RHIBufferBinding> indexBufferBinding;
-    std::optional<RHIBufferBinding> transform;
+    std::optional<RHIBufferBinding> transformBufferBinding;
 
     // For AABBs:
     // Buffer containing D3D12_RAYTRACING_AABB or VkAabbPositionsKHR
@@ -33,14 +33,15 @@ struct RHIBLASGeometryDesc
 struct RHIBLASBuildDesc
 {
     ASGeometryType type = ASGeometryType::Triangles;
-    Span<const RHIBLASGeometryDesc> geometry;
+    Span<const RHIBLASGeometryDesc> geometries;
 };
 
 // RHI version of TLASBuildDesc
 struct RHITLASBuildDesc
 {
+    std::optional<RHIBufferBinding> instancesBinding;
     // Description of each individual instance in the TLAS.
-    Span<const TLASInstanceDesc> instanceDescs;
+    Span<const TLASInstanceDesc> instances;
     // Per-instance BLAS to map each TLAS instance to.
     Span<const NonNullPtr<RHIAccelerationStructure>> perInstanceBLAS;
 };
@@ -53,9 +54,6 @@ struct RHIAccelerationStructureBuildInfo
     u64 scratchByteSize;
     // Required size to update the acceleration structure.
     u64 updateScratchByteSize;
-
-    // Potentially required upload buffer for acceleration structure initialization.
-    std::optional<u64> uploadBufferByteSize;
 };
 
 class RHIAccelerationStructureBase
@@ -90,6 +88,9 @@ public:
                                                                     const RHIBLASBuildDesc& desc) = 0;
     virtual const RHIAccelerationStructureBuildInfo& SetupTLASBuild(RHIAllocator& allocator,
                                                                     const RHITLASBuildDesc& desc) = 0;
+
+    virtual std::vector<std::byte> GetInstanceBufferData(const RHITLASBuildDesc& desc) = 0;
+    virtual u32 GetInstanceBufferStride() = 0;
 
     void FreeBindlessHandles(RHIDescriptorPool& descriptorPool);
     void FreeAllocation(RHIAllocator& allocator);

--- a/src/RHI/RHIBuffer.cpp
+++ b/src/RHI/RHIBuffer.cpp
@@ -56,7 +56,7 @@ BufferViewDesc RHIBufferBase::GetViewDescFromBinding(const BufferBinding& bindin
         .usage = binding.usage,
         .strideByteSize = binding.strideByteSize.value_or(0),
         .offsetByteSize = offset,
-        .rangeByteSize = binding.rangeByteSize.value_or(binding.buffer.desc.byteSize - offset),
+        .rangeByteSize = binding.rangeByteSize.value_or(desc.byteSize - offset),
         .isAccelerationStructure = (binding.buffer.desc.usage & BufferUsage::AccelerationStructure) != 0,
     };
 }

--- a/src/RHI/RHIBuffer.cpp
+++ b/src/RHI/RHIBuffer.cpp
@@ -57,7 +57,8 @@ BufferViewDesc RHIBufferBase::GetViewDescFromBinding(const BufferBinding& bindin
         .strideByteSize = binding.strideByteSize.value_or(0),
         .offsetByteSize = offset,
         .rangeByteSize = binding.rangeByteSize.value_or(desc.byteSize - offset),
-        .isAccelerationStructure = (binding.buffer.desc.usage & BufferUsage::AccelerationStructure) != 0,
+        .isAccelerationStructure =
+            (desc.usage & BufferUsage::AccelerationStructure) == BufferUsage::AccelerationStructure,
     };
 }
 

--- a/src/Vex/Buffer.cpp
+++ b/src/Vex/Buffer.cpp
@@ -71,12 +71,19 @@ BufferDesc BufferDesc::CreateUniformBufferDesc(std::string name, u64 byteSize)
     };
 }
 
-BufferDesc BufferDesc::CreateVertexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead)
+BufferDesc BufferDesc::CreateVertexBufferDesc(std::string name,
+                                              u64 byteSize,
+                                              bool allowShaderRead,
+                                              bool canBeAccelerationStructureSource)
 {
     BufferUsage::Flags usageFlags = BufferUsage::VertexBuffer;
     if (allowShaderRead)
     {
         usageFlags |= BufferUsage::ShaderRead;
+    }
+    if (canBeAccelerationStructureSource)
+    {
+        usageFlags |= BufferUsage::BuildAccelerationStructure;
     }
     return {
         .name = std::move(name),
@@ -86,12 +93,19 @@ BufferDesc BufferDesc::CreateVertexBufferDesc(std::string name, u64 byteSize, bo
     };
 }
 
-BufferDesc BufferDesc::CreateIndexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead)
+BufferDesc BufferDesc::CreateIndexBufferDesc(std::string name,
+                                             u64 byteSize,
+                                             bool allowShaderRead,
+                                             bool canBeAccelerationStructureSource)
 {
     BufferUsage::Flags usageFlags = BufferUsage::IndexBuffer;
     if (allowShaderRead)
     {
         usageFlags |= BufferUsage::ShaderRead;
+    }
+    if (canBeAccelerationStructureSource)
+    {
+        usageFlags |= BufferUsage::BuildAccelerationStructure;
     }
     return {
         .name = std::move(name),

--- a/src/Vex/Buffer.h
+++ b/src/Vex/Buffer.h
@@ -16,25 +16,27 @@ namespace vex
 // Determines how the buffer can be used.
 BEGIN_VEX_ENUM_FLAGS(BufferUsage, u16)
     // Buffers that will never be bound anywhere. Mostly used for staging buffers.
-    None                    = 0,
+    None                        = 0,
     // Buffers that can be read from shaders via Structured or ByteAddress reads.
-    ShaderRead              = 1 << 0,
+    ShaderRead                  = 1 << 0,
     // Buffers with specific alignment constraints and uniformly read across waves.
-    ShaderReadUniform       = 1 << 1,
+    ShaderReadUniform           = 1 << 1,
     // Buffers with read and write operations in shaders via RWStructured or RWByteAddress read/writes.
-    ShaderReadWrite         = 1 << 2,
+    ShaderReadWrite             = 1 << 2,
     // Buffers used for vertex buffers.
-    VertexBuffer            = 1 << 3,
+    VertexBuffer                = 1 << 3,
     // Buffers used for index buffers.
-    IndexBuffer             = 1 << 4,
+    IndexBuffer                 = 1 << 4,
     // Buffers used as parameters for an indirect dispatch.
-    IndirectArgs            = 1 << 5,
+    IndirectArgs                = 1 << 5,
     // Buffers used as a HWRT Acceleration Structure, these also require the ShaderReadWrite usage.
-    AccelerationStructure   = (1 << 6) | ShaderReadWrite,
+    AccelerationStructure       = (1 << 6) | ShaderReadWrite,
     // Buffers used as a scratch buffer for building HWRT Acceleration Structures, these also require the ShaderReadWrite usage.
-    Scratch                 = (1 << 7) | ShaderReadWrite,
+    Scratch                     = (1 << 7) | ShaderReadWrite,
+    // Buffers used as inputs to acceleration structure builds (i.e. vertex, index buffers)
+    BuildAccelerationStructure  = 1 << 8,
     // Buffers used as a ShaderTable for HWRT shaders.
-    ShaderTable             = 1 << 8,
+    ShaderTable                 = 1 << 9,
 END_VEX_ENUM_FLAGS();
 
 // clang-format on
@@ -84,9 +86,15 @@ struct BufferDesc
     // Creates a CPUWrite buffer useable as a Uniform (/constant) Buffer.
     static BufferDesc CreateUniformBufferDesc(std::string name, u64 byteSize);
     // Creates a GPUOnly buffer useable as an Vertex Buffer.
-    static BufferDesc CreateVertexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead = false);
+    static BufferDesc CreateVertexBufferDesc(std::string name,
+                                             u64 byteSize,
+                                             bool allowShaderRead = false,
+                                             bool canBeAccelerationStructureSource = false);
     // Creates a GPUOnly buffer useable as an Index Buffer.
-    static BufferDesc CreateIndexBufferDesc(std::string name, u64 byteSize, bool allowShaderRead = false);
+    static BufferDesc CreateIndexBufferDesc(std::string name,
+                                            u64 byteSize,
+                                            bool allowShaderRead = false,
+                                            bool canBeAccelerationStructureSource = false);
     // Creates a CPUWrite staging buffer useful for uploading data to GPUOnly resources.
     static BufferDesc CreateStagingBufferDesc(std::string name,
                                               u64 byteSize,

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -1078,7 +1078,7 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
     Buffer instanceBuffer = CreateTemporaryBuffer({
         .name = accelStruct.GetDesc().name + "_build_tlas_instances",
         .byteSize = instanceData.size(),
-        .usage = BufferUsage::ShaderRead | BufferUsage::BuildAccelerationStructure,
+        .usage = BufferUsage::BuildAccelerationStructure,
     });
     RHIBuffer& rhiInstanceBuffer = graphics->GetRHIBuffer(instanceBuffer.handle);
     EnqueueDataUpload(instanceBuffer, instanceData);

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -908,6 +908,21 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
         u32 transformIndex = 0;
         for (const BLASGeometryDesc& blasGeometry : desc.geometry)
         {
+            // TODO(https://trello.com/c/srGndUSP): Handle other vertex formats, this should be cross-referenced
+            // with Vulkan to make sure only formats supported by both APIs are accepted.
+            if (*blasGeometry.vertexBufferBinding.strideByteSize > sizeof(float) * 3)
+            {
+                VEX_LOG(
+                    Warning,
+                    "Vex currently does not support acceleration structure geometry whose vertices have a format "
+                    "different to 12 bytes (RGB32). Your vertex buffer binding has a different stride than this, this "
+                    "is ok as long as the user is aware that elements outside the first 12 bytes will be ignored.");
+            }
+
+            VEX_ASSERT(*blasGeometry.vertexBufferBinding.strideByteSize >= sizeof(float) * 3,
+                       "Vex currently does not support acceleration structure geometry whose vertices have a stride "
+                       "smaller than 12 bytes.");
+
             RHIBLASGeometryDesc rhiBLASGeometry{
                 .vertexBufferBinding =
                     RHIBufferBinding(blasGeometry.vertexBufferBinding,
@@ -917,6 +932,8 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
 
             if (blasGeometry.indexBufferBinding.has_value())
             {
+                VEX_CHECK(blasGeometry.indexBufferBinding->strideByteSize == sizeof(u32),
+                          "Vex only supports 32bit index types")
                 rhiBLASGeometry.indexBufferBinding =
                     RHIBufferBinding(*blasGeometry.indexBufferBinding,
                                      graphics->GetRHIBuffer(blasGeometry.indexBufferBinding->buffer.handle));
@@ -924,7 +941,7 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
 
             if (blasGeometry.transform.has_value())
             {
-                rhiBLASGeometry.transform = RHIBufferBinding{
+                rhiBLASGeometry.transformBufferBinding = RHIBufferBinding{
                     .binding = { .buffer = transformBuffer,
                                  .offsetByteSize = TransformMatrixSize * transformIndex,
                                  .rangeByteSize = TransformMatrixSize },
@@ -996,13 +1013,13 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
     const RHIAccelerationStructureBuildInfo& buildInfo =
         graphics->GetRHIAccelerationStructure(accelerationStructure.handle)
             .SetupBLASBuild(*graphics->allocator,
-                            RHIBLASBuildDesc{ .type = desc.type, .geometry = rhiBLASGeometryDescs });
+                            RHIBLASBuildDesc{ .type = desc.type, .geometries = rhiBLASGeometryDescs });
 
     BufferDesc scratchBufferDesc{
         .name =
             graphics->GetRHIAccelerationStructure(accelerationStructure.handle).GetDesc().name + "_build_blas_scratch",
         .byteSize = buildInfo.scratchByteSize,
-        .usage = BufferUsage::Scratch,
+        .usage = BufferUsage::AccelerationStructure | BufferUsage::Scratch,
     };
     Buffer scratchBuffer = CreateTemporaryBuffer(scratchBufferDesc);
 
@@ -1035,29 +1052,41 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
         .dstAccess = RHIBarrierAccess::AccelerationStructureRead,
     });
 
-    const RHITLASBuildDesc rhiTLASDesc{
-        .instanceDescs = desc.instances,
+    RHITLASBuildDesc rhiTLASDesc{
+        .instances = desc.instances,
         .perInstanceBLAS = perInstanceBLAS,
     };
 
-    const RHIAccelerationStructureBuildInfo& buildInfo =
-        graphics->GetRHIAccelerationStructure(accelerationStructure.handle)
-            .SetupTLASBuild(*graphics->allocator, rhiTLASDesc);
+    RHIAccelerationStructure& accelStruct = graphics->GetRHIAccelerationStructure(accelerationStructure.handle);
+    std::vector<std::byte> instanceData = accelStruct.GetInstanceBufferData(rhiTLASDesc);
+
+    BufferDesc instancesBufferDesc{
+        .name = accelStruct.GetDesc().name + "_build_tlas_instances",
+        .byteSize = instanceData.size(),
+        .usage = BufferUsage::AccelerationStructure | BufferUsage::ReadWriteBuffer,
+    };
+    Buffer instanceBuffer = CreateTemporaryBuffer(instancesBufferDesc);
+    RHIBuffer& rhiInstanceBuffer = graphics->GetRHIBuffer(instanceBuffer.handle);
+    EnqueueDataUpload(instanceBuffer, instanceData);
+
+    BufferBinding binding =
+        BufferBinding::CreateStructuredBuffer(instanceBuffer, accelStruct.GetInstanceBufferStride());
+    rhiTLASDesc.instancesBinding = RHIBufferBinding{ binding, rhiInstanceBuffer };
+
+    const RHIAccelerationStructureBuildInfo& buildInfo = accelStruct.SetupTLASBuild(*graphics->allocator, rhiTLASDesc);
     BufferDesc scratchBufferDesc{
-        .name =
-            graphics->GetRHIAccelerationStructure(accelerationStructure.handle).GetDesc().name + "_build_tlas_scratch",
+        .name = accelStruct.GetDesc().name + "_build_tlas_scratch",
         .byteSize = buildInfo.scratchByteSize,
-        .usage = BufferUsage::Scratch,
+        .usage = BufferUsage::AccelerationStructure | BufferUsage::Scratch,
     };
     Buffer scratchBuffer = CreateTemporaryBuffer(scratchBufferDesc);
-    Buffer uploadBuffer = CreateTemporaryStagingBuffer(
-        graphics->GetRHIAccelerationStructure(accelerationStructure.handle).GetDesc().name + "_build_tlas",
-        *buildInfo.uploadBufferByteSize);
+    Barrier(scratchBuffer, RHIBarrierSync::BuildAccelerationStructure, RHIBarrierAccess::AccelerationStructureWrite);
+    Barrier(instanceBuffer, RHIBarrierSync::BuildAccelerationStructure, RHIBarrierAccess::ShaderRead);
 
     FlushBarriers();
-    cmdList->BuildTLAS(graphics->GetRHIAccelerationStructure(accelerationStructure.handle),
+    cmdList->BuildTLAS(accelStruct,
                        graphics->GetRHIBuffer(scratchBuffer.handle),
-                       graphics->GetRHIBuffer(uploadBuffer.handle),
+                       graphics->GetRHIBuffer(instanceBuffer.handle),
                        rhiTLASDesc);
 }
 

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -870,6 +870,19 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
 
     if (desc.type == ASGeometryType::Triangles)
     {
+        for (const BLASGeometryDesc& desc : desc.geometry)
+        {
+            if (desc.indexBufferBinding)
+            {
+                VEX_CHECK(desc.indexBufferBinding->buffer.desc.usage & BufferUsage::BuildAccelerationStructure,
+                          "Index buffer binding must have the BuildAccelerationStructure usage to be used as source "
+                          "for building a BLAS");
+            }
+            VEX_CHECK(desc.vertexBufferBinding.buffer.desc.usage & BufferUsage::BuildAccelerationStructure,
+                      "Vertex buffer binding must have the BuildAccelerationStructure usage to be used as source for "
+                      "building a BLAS");
+        }
+
         // Upload all the transforms into one GPU/ staging buffer.
         std::vector<std::array<float, 3 * 4>> transformsToUpload;
         // Conservative allocation.
@@ -1063,7 +1076,7 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
     Buffer instanceBuffer = CreateTemporaryBuffer({
         .name = accelStruct.GetDesc().name + "_build_tlas_instances",
         .byteSize = instanceData.size(),
-        .usage = BufferUsage::ShaderRead,
+        .usage = BufferUsage::ShaderRead | BufferUsage::BuildAccelerationStructure,
     });
     RHIBuffer& rhiInstanceBuffer = graphics->GetRHIBuffer(instanceBuffer.handle);
     EnqueueDataUpload(instanceBuffer, instanceData);

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -911,7 +911,7 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
         }
 
         // Ensure that vertex/index buffers have had time to be written-to correctly.
-        EnqueueGlobalBarrier(RHIGlobalBarrier{
+        EnqueueGlobalBarrier({
             .srcSync = RHIBarrierSync::AllCommands,
             .dstSync = RHIBarrierSync::BuildAccelerationStructure,
             .srcAccess = RHIBarrierAccess::MemoryWrite,
@@ -1298,7 +1298,7 @@ void CommandContext::InferResourceBarriers(RHIBarrierSync syncStage, Span<const 
             Visitor{ [this, syncStage](const BufferBinding& bufferBinding)
                      {
                          using enum BufferBindingUsage;
-                         RHIBarrierAccess dstAccess;
+                         RHIBarrierAccess dstAccess{};
                          switch (bufferBinding.usage)
                          {
                          case UniformBuffer:
@@ -1463,6 +1463,11 @@ std::optional<RHIDrawResources> CommandContext::PrepareDrawCall(const DrawDesc& 
         cmdList->SetInputAssembly(drawDesc.inputAssembly);
         cachedInputAssembly = drawDesc.inputAssembly;
     }
+
+    EnqueueGlobalBarrier({ .srcSync = RHIBarrierSync::AllCommands,
+                           .dstSync = RHIBarrierSync::AllGraphics,
+                           .srcAccess = RHIBarrierAccess::MemoryWrite,
+                           .dstAccess = RHIBarrierAccess::VertexInputRead });
 
     // Bind Vertex Buffer(s)
     SetVertexBuffers(drawBindings.vertexBuffersFirstSlot, drawBindings.vertexBuffers);

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -861,6 +861,7 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
 {
     VEX_CHECK(GPhysicalDevice->IsFeatureSupported(Feature::RayTracing),
               "Your GPU does not support ray tracing, unable to build BLAS!");
+    VEX_CHECK(accelerationStructure.handle.IsValid(), "Provided acceleration structure must be valid!");
     VEX_CHECK(accelerationStructure.desc.type == ASType::BottomLevel,
               "BuildBLAS only accepts bottom level acceleration structures...");
     VEX_CHECK(!desc.geometry.empty(), "Cannot build an empty BLAS...");
@@ -1045,6 +1046,7 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
 {
     VEX_CHECK(GPhysicalDevice->IsFeatureSupported(Feature::RayTracing),
               "Your GPU does not support ray tracing, unable to build TLAS!");
+    VEX_CHECK(accelerationStructure.handle.IsValid(), "Provided acceleration structure must be valid!");
     VEX_CHECK(accelerationStructure.desc.type == ASType::TopLevel,
               "BuildTLAS only accepts top level acceleration structures...");
     VEX_CHECK(!desc.instances.empty(), "Cannot build an empty TLAS...");

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -1019,7 +1019,7 @@ void CommandContext::BuildBLAS(const AccelerationStructure& accelerationStructur
         .name =
             graphics->GetRHIAccelerationStructure(accelerationStructure.handle).GetDesc().name + "_build_blas_scratch",
         .byteSize = buildInfo.scratchByteSize,
-        .usage = BufferUsage::AccelerationStructure | BufferUsage::Scratch,
+        .usage = BufferUsage::Scratch,
     };
     Buffer scratchBuffer = CreateTemporaryBuffer(scratchBufferDesc);
 
@@ -1063,7 +1063,7 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
     BufferDesc instancesBufferDesc{
         .name = accelStruct.GetDesc().name + "_build_tlas_instances",
         .byteSize = instanceData.size(),
-        .usage = BufferUsage::AccelerationStructure | BufferUsage::ReadWriteBuffer,
+        .usage = BufferUsage::AccelerationStructure,
     };
     Buffer instanceBuffer = CreateTemporaryBuffer(instancesBufferDesc);
     RHIBuffer& rhiInstanceBuffer = graphics->GetRHIBuffer(instanceBuffer.handle);
@@ -1080,8 +1080,8 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
         .usage = BufferUsage::AccelerationStructure | BufferUsage::Scratch,
     };
     Buffer scratchBuffer = CreateTemporaryBuffer(scratchBufferDesc);
-    Barrier(scratchBuffer, RHIBarrierSync::BuildAccelerationStructure, RHIBarrierAccess::AccelerationStructureWrite);
-    Barrier(instanceBuffer, RHIBarrierSync::BuildAccelerationStructure, RHIBarrierAccess::ShaderRead);
+    Barrier(scratchBuffer, RHIBarrierAccess::AccelerationStructureWrite);
+    Barrier(instanceBuffer, RHIBarrierAccess::ShaderRead);
 
     FlushBarriers();
     cmdList->BuildTLAS(accelStruct,

--- a/src/Vex/CommandContext.cpp
+++ b/src/Vex/CommandContext.cpp
@@ -1060,12 +1060,11 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
     RHIAccelerationStructure& accelStruct = graphics->GetRHIAccelerationStructure(accelerationStructure.handle);
     std::vector<std::byte> instanceData = accelStruct.GetInstanceBufferData(rhiTLASDesc);
 
-    BufferDesc instancesBufferDesc{
+    Buffer instanceBuffer = CreateTemporaryBuffer({
         .name = accelStruct.GetDesc().name + "_build_tlas_instances",
         .byteSize = instanceData.size(),
-        .usage = BufferUsage::AccelerationStructure,
-    };
-    Buffer instanceBuffer = CreateTemporaryBuffer(instancesBufferDesc);
+        .usage = BufferUsage::ShaderRead,
+    });
     RHIBuffer& rhiInstanceBuffer = graphics->GetRHIBuffer(instanceBuffer.handle);
     EnqueueDataUpload(instanceBuffer, instanceData);
 
@@ -1074,14 +1073,16 @@ void CommandContext::BuildTLAS(const AccelerationStructure& accelerationStructur
     rhiTLASDesc.instancesBinding = RHIBufferBinding{ binding, rhiInstanceBuffer };
 
     const RHIAccelerationStructureBuildInfo& buildInfo = accelStruct.SetupTLASBuild(*graphics->allocator, rhiTLASDesc);
-    BufferDesc scratchBufferDesc{
+    Buffer scratchBuffer = CreateTemporaryBuffer({
         .name = accelStruct.GetDesc().name + "_build_tlas_scratch",
         .byteSize = buildInfo.scratchByteSize,
-        .usage = BufferUsage::AccelerationStructure | BufferUsage::Scratch,
-    };
-    Buffer scratchBuffer = CreateTemporaryBuffer(scratchBufferDesc);
-    Barrier(scratchBuffer, RHIBarrierAccess::AccelerationStructureWrite);
-    Barrier(instanceBuffer, RHIBarrierAccess::ShaderRead);
+        .usage = BufferUsage::Scratch,
+    });
+
+    EnqueueGlobalBarrier({ .srcSync = RHIBarrierSync::Copy,
+                           .dstSync = RHIBarrierSync::BuildAccelerationStructure,
+                           .srcAccess = RHIBarrierAccess::CopyDest,
+                           .dstAccess = RHIBarrierAccess::MemoryRead });
 
     FlushBarriers();
     cmdList->BuildTLAS(accelStruct,

--- a/src/Vex/Shaders/ShaderCompiler.cpp
+++ b/src/Vex/Shaders/ShaderCompiler.cpp
@@ -55,7 +55,8 @@ ShaderEnvironment ShaderCompiler::CreateShaderEnvironment()
     env.defines.emplace_back("VEX_DEBUG", std::to_string(VEX_DEBUG));
     env.defines.emplace_back("VEX_DEVELOPMENT", std::to_string(VEX_DEVELOPMENT));
     env.defines.emplace_back("VEX_SHIPPING", std::to_string(VEX_SHIPPING));
-    env.defines.emplace_back("VEX_RAYTRACING", std::to_string(GPhysicalDevice->IsFeatureSupported(Feature::RayTracing)));
+    env.defines.emplace_back("VEX_RAYTRACING",
+                             std::to_string(GPhysicalDevice->IsFeatureSupported(Feature::RayTracing)));
     env.defines.emplace_back("VEX_VULKAN", std::to_string(VEX_VULKAN));
     env.defines.emplace_back("VEX_DX12", std::to_string(VEX_DX12));
     return env;
@@ -214,8 +215,11 @@ std::expected<void, std::string> ShaderCompiler::CompileShader(CompilerBase* com
                 {
                     const std::vector<byte>& shaderBytecode = result.compiledCode;
 
+                    std::string filename = shader.key.path.stem().string() + "_" +
+                                           std::string(magic_enum::enum_name(shader.key.type)) + "_" +
+                                           shader.key.entryPoint;
                     std::filesystem::path outputPath =
-                        std::filesystem::current_path() / "VexOutput_SHADER_BYTECODE" / shader.key.path.filename();
+                        std::filesystem::current_path() / "VexOutput_SHADER_BYTECODE" / filename;
 #if VEX_VULKAN
                     outputPath.replace_extension(".spv"); // or ".spirv"
 #elif VEX_DX12

--- a/src/Vulkan/RHI/VkAccelerationStructure.cpp
+++ b/src/Vulkan/RHI/VkAccelerationStructure.cpp
@@ -271,7 +271,7 @@ void VkAccelerationStructure::BuildAccelerationStructure(::vk::AccelerationStruc
     BufferDesc asBufferDesc{
         .name = GetDesc().name,
         .byteSize = prebuildInfo.asByteSize,
-        .usage = BufferUsage::AccelerationStructure | BufferUsage::ReadWriteBuffer,
+        .usage = BufferUsage::AccelerationStructure,
         .memoryLocality = ResourceMemoryLocality::GPUOnly,
     };
     accelerationStructure = RHIBuffer(ctx, allocator, asBufferDesc);

--- a/src/Vulkan/RHI/VkAccelerationStructure.cpp
+++ b/src/Vulkan/RHI/VkAccelerationStructure.cpp
@@ -103,7 +103,7 @@ const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupBLASBuild
             u32 triangleCount = vertexCount / 3;
             if (geom.indexBufferBinding)
             {
-                triangleCount = BindingToOffsetCount(geom.indexBufferBinding, sizeof(u32)).second;
+                triangleCount = BindingToOffsetCount(geom.indexBufferBinding, sizeof(u32)).second / 3;
             }
 
             geometryCount.push_back(triangleCount);

--- a/src/Vulkan/RHI/VkAccelerationStructure.cpp
+++ b/src/Vulkan/RHI/VkAccelerationStructure.cpp
@@ -14,10 +14,7 @@ namespace
 ::vk::TransformMatrixKHR GetVkTransformMatrix(std::array<float, 3 * 4> matrix)
 {
     ::vk::TransformMatrixKHR mat;
-    for (int i = 0; i < matrix.size(); ++i)
-    {
-        mat.matrix[i / 4][i % 4] = matrix[i];
-    }
+    std::uninitialized_copy_n(matrix.data(), 12, &mat.matrix[0][0]);
     return mat;
 }
 } // namespace

--- a/src/Vulkan/RHI/VkAccelerationStructure.cpp
+++ b/src/Vulkan/RHI/VkAccelerationStructure.cpp
@@ -96,9 +96,9 @@ const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupBLASBuild
             VEX_ASSERT(geom.vertexBufferBinding);
             VEX_ASSERT(geom.vertexBufferBinding->binding.strideByteSize);
 
-            static constexpr u32 vertexByteStride = sizeof(float) * 3;
+            static constexpr u32 VertexByteStride = sizeof(float) * 3;
 
-            auto [firstVertex, vertexCount] = BindingToOffsetCount(geom.vertexBufferBinding, vertexByteStride);
+            auto [firstVertex, vertexCount] = BindingToOffsetCount(geom.vertexBufferBinding, VertexByteStride);
 
             u32 triangleCount = vertexCount / 3;
             if (geom.indexBufferBinding)
@@ -129,7 +129,7 @@ const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupBLASBuild
                 .primitiveCount = triangleCount,
                 .primitiveOffset = static_cast<u32>(geom.indexBufferBinding
                                                         ? geom.indexBufferBinding->binding.offsetByteSize.value_or(0)
-                                                        : firstVertex * vertexByteStride),
+                                                        : firstVertex * VertexByteStride),
                 .firstVertex = 0,
                 .transformOffset =
                     geom.transformBufferBinding

--- a/src/Vulkan/RHI/VkAccelerationStructure.cpp
+++ b/src/Vulkan/RHI/VkAccelerationStructure.cpp
@@ -1,28 +1,287 @@
 #include "VkAccelerationStructure.h"
 
+#include <Vex/PhysicalDevice.h>
+#include <Vex/Utility/ByteUtils.h>
+
+#include <Vulkan/VkErrorHandler.h>
+#include <Vulkan/VkGPUContext.h>
+
 namespace vex::vk
 {
 
-VkAccelerationStructure::VkAccelerationStructure(const ASDesc& desc)
-    : RHIAccelerationStructureBase(desc)
+namespace
 {
-    VEX_NOT_YET_IMPLEMENTED();
+::vk::TransformMatrixKHR GetVkTransformMatrix(std::array<float, 3 * 4> matrix)
+{
+    ::vk::TransformMatrixKHR mat;
+    for (int i = 0; i < matrix.size(); ++i)
+    {
+        mat.matrix[i / 4][i % 4] = matrix[i];
+    }
+    return mat;
+}
+} // namespace
+
+::vk::GeometryFlagsKHR GeometryFlagsToVkGeometryFlags(ASGeometry::Flags flags)
+{
+    ::vk::GeometryFlagsKHR vkFlags{};
+    if (flags & ASGeometry::Opaque)
+        vkFlags |= ::vk::GeometryFlagBitsKHR::eOpaque;
+    if (flags & ASGeometry::NoDuplicateAnyHitInvocation)
+        vkFlags |= ::vk::GeometryFlagBitsKHR::eNoDuplicateAnyHitInvocation;
+    return vkFlags;
+}
+
+::vk::GeometryInstanceFlagsKHR ASInstanceFlagsToVkGeometryInstanceFlags(ASInstance::Flags flags)
+{
+    ::vk::GeometryInstanceFlagsKHR vkFlags{};
+    if (flags & ASInstance::ForceNonOpaque)
+        vkFlags |= ::vk::GeometryInstanceFlagBitsKHR::eForceNoOpaque;
+    if (flags & ASInstance::ForceOpaque)
+        vkFlags |= ::vk::GeometryInstanceFlagBitsKHR::eForceOpaque;
+    if (flags & ASInstance::TriangleCullDisable)
+        vkFlags |= ::vk::GeometryInstanceFlagBitsKHR::eTriangleCullDisable;
+    if (flags & ASInstance::TriangleFrontCounterClockwise)
+        vkFlags |= ::vk::GeometryInstanceFlagBitsKHR::eTriangleFrontCounterclockwise;
+    return vkFlags;
+}
+
+::vk::BuildAccelerationStructureFlagsKHR ASBuildFlagsToVkASBuildFlags(ASBuild::Flags flags)
+{
+    using enum ::vk::BuildAccelerationStructureFlagBitsKHR;
+    ::vk::BuildAccelerationStructureFlagsKHR vkFlags{};
+    if (flags & ASBuild::AllowCompaction)
+        vkFlags |= eAllowCompaction;
+    if (flags & ASBuild::AllowUpdate)
+        vkFlags |= eAllowUpdate;
+    if (flags & ASBuild::MinimizeMemory)
+        vkFlags |= eLowMemory;
+    if (flags & ASBuild::PreferFastBuild)
+        vkFlags |= ePreferFastBuild;
+    if (flags & ASBuild::PreferFastTrace)
+        vkFlags |= ePreferFastTrace;
+    return vkFlags;
+}
+
+VkAccelerationStructure::VkAccelerationStructure(NonNullPtr<VkGPUContext> ctx, const ASDesc& desc)
+    : RHIAccelerationStructureBase(desc)
+    , ctx{ ctx }
+{
 }
 
 const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupBLASBuild(RHIAllocator& allocator,
                                                                                  const RHIBLASBuildDesc& desc)
 {
-    VEX_NOT_YET_IMPLEMENTED();
-    static RHIAccelerationStructureBuildInfo bi{};
-    return bi;
+    geometries.clear();
+    ranges.clear();
+    geometryCount.clear();
+
+    geometries.reserve(desc.geometries.size());
+    ranges.reserve(desc.geometries.size());
+    geometryCount.reserve(desc.geometries.size());
+
+    auto bindingToOffsetCount = [](const std::optional<RHIBufferBinding>& binding,
+                                   u32 fallbackStride) -> std::pair<u32, u32> // offset, count
+    {
+        if (!binding)
+            return {};
+
+        return { static_cast<u32>(binding->binding.offsetByteSize.value_or(0) / fallbackStride),
+                 static_cast<u32>(binding->binding.rangeByteSize.value_or(binding->buffer->GetDesc().byteSize) /
+                                  fallbackStride) };
+    };
+
+    for (const RHIBLASGeometryDesc& geom : desc.geometries)
+    {
+        ::vk::AccelerationStructureGeometryKHR geometry{};
+        if (desc.type == ASGeometryType::Triangles)
+        {
+            VEX_ASSERT(geom.vertexBufferBinding);
+            VEX_ASSERT(geom.vertexBufferBinding->binding.strideByteSize);
+
+            static constexpr u32 vertexByteStride = sizeof(float) * 3;
+
+            auto [firstVertex, vertexCount] = bindingToOffsetCount(geom.vertexBufferBinding, vertexByteStride);
+
+            u32 triangleCount = vertexCount / 3;
+            if (geom.indexBufferBinding)
+            {
+                triangleCount = bindingToOffsetCount(geom.indexBufferBinding, sizeof(u32)).second;
+            }
+
+            geometryCount.push_back(triangleCount);
+
+            BufferBinding vertexBufferBinding = geom.vertexBufferBinding->binding;
+
+            geometry = ::vk::AccelerationStructureGeometryKHR{
+                .geometryType = ::vk::GeometryTypeKHR::eTriangles,
+                .geometry = {
+                    .triangles = {
+                        .vertexFormat = ::vk::Format::eR32G32B32Sfloat,
+                        .vertexData = { geom.vertexBufferBinding->buffer->GetDeviceAddress() },
+                        .vertexStride = sizeof(float) * 3,
+                        .maxVertex = vertexCount - 1,
+                        .indexType = geom.indexBufferBinding ? ::vk::IndexType::eUint32 : ::vk::IndexType::eNoneKHR,
+                        .indexData = { geom.indexBufferBinding ? geom.indexBufferBinding->buffer->GetDeviceAddress() : ::vk::DeviceAddress{} },
+                        .transformData = { geom.transformBufferBinding ? geom.transformBufferBinding->buffer->GetDeviceAddress() : ::vk::DeviceAddress{} },
+                    },
+                },
+            };
+
+            ranges.push_back(::vk::AccelerationStructureBuildRangeInfoKHR{
+                .primitiveCount = triangleCount,
+                .primitiveOffset = static_cast<u32>(geom.indexBufferBinding
+                                                        ? geom.indexBufferBinding->binding.offsetByteSize.value_or(0)
+                                                        : firstVertex * vertexByteStride),
+                .firstVertex = 0,
+                .transformOffset =
+                    geom.transformBufferBinding
+                        ? static_cast<u32>(geom.transformBufferBinding->binding.offsetByteSize.value_or(0))
+                        : 0,
+            });
+        }
+        else if (desc.type == ASGeometryType::AABBs)
+        {
+            VEX_ASSERT(geom.aabbBufferBinding);
+
+            geometry = ::vk::AccelerationStructureGeometryKHR{
+                .geometryType = ::vk::GeometryTypeKHR::eAabbs,
+                .geometry = {
+                    .aabbs = {
+                        .data = { geom.aabbBufferBinding->buffer->GetDeviceAddress() },
+                        .stride = sizeof(VkAabbPositionsKHR),
+                    },
+                },
+            };
+
+            auto [firstAabb, aabbCount] = bindingToOffsetCount(geom.aabbBufferBinding, sizeof(float) * 6);
+
+            geometryCount.push_back(aabbCount);
+            ranges.push_back(::vk::AccelerationStructureBuildRangeInfoKHR{
+                .primitiveCount = aabbCount,
+                .primitiveOffset = static_cast<u32>(geom.aabbBufferBinding->binding.offsetByteSize.value_or(0)),
+            });
+        }
+
+        geometry.flags = GeometryFlagsToVkGeometryFlags(geom.flags);
+
+        geometries.push_back(geometry);
+    }
+
+    BuildAccelerationStructure(::vk::AccelerationStructureTypeKHR::eBottomLevel, allocator);
+
+    return prebuildInfo;
 }
 
 const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupTLASBuild(RHIAllocator& allocator,
                                                                                  const RHITLASBuildDesc& desc)
 {
-    VEX_NOT_YET_IMPLEMENTED();
-    static RHIAccelerationStructureBuildInfo bi{};
-    return bi;
+    geometries.clear();
+    ranges.clear();
+    geometryCount.clear();
+
+    VEX_ASSERT(desc.instancesBinding);
+
+    geometries.push_back(::vk::AccelerationStructureGeometryKHR{
+        .geometryType = ::vk::GeometryTypeKHR::eInstances,
+        .geometry = {
+            .instances = {
+                .data = { desc.instancesBinding->buffer->GetDeviceAddress() }
+            },
+        },
+    });
+
+    auto primitiveCount = static_cast<u32>(desc.instances.size());
+    ranges.push_back({
+        .primitiveCount = primitiveCount,
+        .primitiveOffset = 0,
+    });
+    geometryCount.push_back(primitiveCount);
+
+    BuildAccelerationStructure(::vk::AccelerationStructureTypeKHR::eTopLevel, allocator);
+
+    return prebuildInfo;
+}
+
+std::vector<std::byte> VkAccelerationStructure::GetInstanceBufferData(const RHITLASBuildDesc& desc)
+{
+    std::vector<::vk::AccelerationStructureInstanceKHR> instances;
+    for (u32 i = 0; i < desc.instances.size(); i++)
+    {
+        const TLASInstanceDesc& instance = desc.instances[i];
+        const NonNullPtr<RHIAccelerationStructure> as = desc.perInstanceBLAS[i];
+
+        instances.push_back(::vk::AccelerationStructureInstanceKHR{
+            .transform = GetVkTransformMatrix(instance.transform),
+            .instanceCustomIndex = instance.instanceID,
+            .mask = instance.instanceMask,
+            .instanceShaderBindingTableRecordOffset = instance.instanceContributionToHitGroupIndex,
+            .flags = static_cast<VkGeometryInstanceFlagsKHR>(
+                ASInstanceFlagsToVkGeometryInstanceFlags(instance.instanceFlags)),
+            .accelerationStructureReference = as->GetNativeAddress(),
+        });
+    }
+
+    std::span byteSpan{ reinterpret_cast<std::byte*>(instances.data()),
+                        instances.size() * sizeof(::vk::AccelerationStructureInstanceKHR) };
+    return { byteSpan.begin(), byteSpan.end() };
+}
+
+u32 VkAccelerationStructure::GetInstanceBufferStride()
+{
+    return sizeof(::vk::AccelerationStructureInstanceKHR);
+}
+
+::vk::DeviceAddress VkAccelerationStructure::GetNativeAddress()
+{
+    return VEX_VK_CHECK <<= ctx->device.getAccelerationStructureAddressKHR({
+               .accelerationStructure = *vkAccelerationStructure,
+           });
+}
+
+void VkAccelerationStructure::BuildAccelerationStructure(::vk::AccelerationStructureTypeKHR type,
+                                                         RHIAllocator& allocator)
+{
+    ::vk::AccelerationStructureBuildGeometryInfoKHR asBuildInfo{
+        .type = type,
+        .flags = ASBuildFlagsToVkASBuildFlags(GetDesc().buildFlags),
+        .mode = ::vk::BuildAccelerationStructureModeKHR::eBuild,
+        .geometryCount = static_cast<u32>(geometries.size()),
+        .pGeometries = geometries.data(), // The geometry to build the acceleration structure from
+    };
+
+    // TODO(https://trello.com/c/ZUZPpce4): Move this to VkPhysicalDevice class
+    ::vk::StructureChain<::vk::PhysicalDeviceProperties2, ::vk::PhysicalDeviceAccelerationStructurePropertiesKHR>
+        propertiesChain = ctx->physDevice.getProperties2<::vk::PhysicalDeviceProperties2,
+                                                         ::vk::PhysicalDeviceAccelerationStructurePropertiesKHR>();
+    auto minASscratchAlignment = propertiesChain.get<::vk::PhysicalDeviceAccelerationStructurePropertiesKHR>()
+                                     .minAccelerationStructureScratchOffsetAlignment;
+
+    ::vk::AccelerationStructureBuildSizesInfoKHR asBuildSize =
+        ctx->device.getAccelerationStructureBuildSizesKHR(::vk::AccelerationStructureBuildTypeKHR::eDevice,
+                                                          asBuildInfo,
+                                                          geometryCount);
+
+    prebuildInfo = {
+        .asByteSize = asBuildSize.accelerationStructureSize,
+        .scratchByteSize = AlignUp(static_cast<u32>(asBuildSize.buildScratchSize), minASscratchAlignment),
+        .updateScratchByteSize = asBuildSize.updateScratchSize,
+    };
+
+    BufferDesc asBufferDesc{
+        .name = GetDesc().name,
+        .byteSize = prebuildInfo.asByteSize,
+        .usage = BufferUsage::AccelerationStructure | BufferUsage::ReadWriteBuffer,
+        .memoryLocality = ResourceMemoryLocality::GPUOnly,
+    };
+    accelerationStructure = RHIBuffer(ctx, allocator, asBufferDesc);
+
+    ::vk::AccelerationStructureCreateInfoKHR asCreateInfo{
+        .buffer = accelerationStructure->GetNativeBuffer(),
+        .size = asBuildSize.accelerationStructureSize,
+        .type = type,
+    };
+    vkAccelerationStructure = VEX_VK_CHECK <<= ctx->device.createAccelerationStructureKHRUnique(asCreateInfo);
 }
 
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkAccelerationStructure.cpp
+++ b/src/Vulkan/RHI/VkAccelerationStructure.cpp
@@ -77,7 +77,7 @@ const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupBLASBuild
     ranges.reserve(desc.geometries.size());
     geometryCount.reserve(desc.geometries.size());
 
-    auto bindingToOffsetCount = [](const std::optional<RHIBufferBinding>& binding,
+    auto BindingToOffsetCount = [](const std::optional<RHIBufferBinding>& binding,
                                    u32 fallbackStride) -> std::pair<u32, u32> // offset, count
     {
         if (!binding)
@@ -98,12 +98,12 @@ const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupBLASBuild
 
             static constexpr u32 vertexByteStride = sizeof(float) * 3;
 
-            auto [firstVertex, vertexCount] = bindingToOffsetCount(geom.vertexBufferBinding, vertexByteStride);
+            auto [firstVertex, vertexCount] = BindingToOffsetCount(geom.vertexBufferBinding, vertexByteStride);
 
             u32 triangleCount = vertexCount / 3;
             if (geom.indexBufferBinding)
             {
-                triangleCount = bindingToOffsetCount(geom.indexBufferBinding, sizeof(u32)).second;
+                triangleCount = BindingToOffsetCount(geom.indexBufferBinding, sizeof(u32)).second;
             }
 
             geometryCount.push_back(triangleCount);
@@ -151,7 +151,7 @@ const RHIAccelerationStructureBuildInfo& VkAccelerationStructure::SetupBLASBuild
                 },
             };
 
-            auto [firstAabb, aabbCount] = bindingToOffsetCount(geom.aabbBufferBinding, sizeof(float) * 6);
+            auto [firstAabb, aabbCount] = BindingToOffsetCount(geom.aabbBufferBinding, sizeof(float) * 6);
 
             geometryCount.push_back(aabbCount);
             ranges.push_back(::vk::AccelerationStructureBuildRangeInfoKHR{

--- a/src/Vulkan/RHI/VkAccelerationStructure.h
+++ b/src/Vulkan/RHI/VkAccelerationStructure.h
@@ -4,16 +4,32 @@
 
 namespace vex::vk
 {
-
 class VkAccelerationStructure final : public RHIAccelerationStructureBase
 {
 public:
-    VkAccelerationStructure(const ASDesc& desc);
+    VkAccelerationStructure(NonNullPtr<VkGPUContext> ctx, const ASDesc& desc);
 
     virtual const RHIAccelerationStructureBuildInfo& SetupBLASBuild(RHIAllocator& allocator,
                                                                     const RHIBLASBuildDesc& desc) override;
     virtual const RHIAccelerationStructureBuildInfo& SetupTLASBuild(RHIAllocator& allocator,
                                                                     const RHITLASBuildDesc& desc) override;
+
+    virtual std::vector<std::byte> GetInstanceBufferData(const RHITLASBuildDesc& desc) override;
+    virtual u32 GetInstanceBufferStride() override;
+
+    std::vector<u32> geometryCount;
+    std::vector<::vk::AccelerationStructureGeometryKHR> geometries;
+    std::vector<::vk::AccelerationStructureBuildRangeInfoKHR> ranges;
+    NonNullPtr<VkGPUContext> ctx;
+
+    ::vk::UniqueAccelerationStructureKHR vkAccelerationStructure;
+
+    ::vk::DeviceAddress GetNativeAddress();
+
+    void BuildAccelerationStructure(::vk::AccelerationStructureTypeKHR type, RHIAllocator& allocator);
 };
 
+::vk::GeometryInstanceFlagsKHR ASInstanceFlagsToVkGeometryInstanceFlags(ASInstance::Flags flags);
+::vk::GeometryFlagsKHR GeometryFlagsToVkGeometryFlags(ASGeometry::Flags flags);
+::vk::BuildAccelerationStructureFlagsKHR ASBuildFlagsToVkASBuildFlags(ASBuild::Flags flags);
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkAllocator.cpp
+++ b/src/Vulkan/RHI/VkAllocator.cpp
@@ -117,8 +117,11 @@ void VkAllocator::OnPageAllocated(PageHandle handle, u32 memoryTypeIndex)
     auto& heapList = memoryPagesByType[memoryTypeIndex];
     u64 pageByteSize = pageInfos[memoryTypeIndex][handle].GetByteSize();
 
-    ::vk::DeviceMemory allocatedMemory = VEX_VK_CHECK <<=
-        ctx->device.allocateMemory({ .allocationSize = pageByteSize, .memoryTypeIndex = memoryTypeIndex });
+    ::vk::MemoryAllocateFlagsInfo allocInfo;
+    allocInfo.flags = ::vk::MemoryAllocateFlagBits::eDeviceAddress;
+
+    ::vk::DeviceMemory allocatedMemory = VEX_VK_CHECK <<= ctx->device.allocateMemory(
+        { .pNext = &allocInfo, .allocationSize = pageByteSize, .memoryTypeIndex = memoryTypeIndex });
 
     void* ptr = nullptr;
     if (AllocatorUtils::IsMemoryTypeIndexMappable(ctx->physDevice, memoryTypeIndex))

--- a/src/Vulkan/RHI/VkBuffer.cpp
+++ b/src/Vulkan/RHI/VkBuffer.cpp
@@ -16,7 +16,8 @@ namespace vex::vk
 static ::vk::BufferUsageFlags GetVkBufferUsageFromDesc(const BufferDesc& desc)
 {
     using enum ::vk::BufferUsageFlagBits;
-    ::vk::BufferUsageFlags flags = eTransferSrc;
+    // TODO: Figure out implication of eAccelerationStructureBuildInputReadOnlyKHR needed when uploading to AS
+    ::vk::BufferUsageFlags flags = eTransferSrc | eShaderDeviceAddress | eAccelerationStructureBuildInputReadOnlyKHR;
     if (desc.usage & BufferUsage::ShaderReadUniform)
     {
         flags |= eUniformBuffer;
@@ -41,6 +42,10 @@ static ::vk::BufferUsageFlags GetVkBufferUsageFromDesc(const BufferDesc& desc)
     {
         flags |= eAccelerationStructureStorageKHR;
     }
+    if (desc.usage & BufferUsage::ShaderTable)
+    {
+        flags |= eShaderBindingTableKHR;
+    }
     return flags;
 }
 
@@ -56,7 +61,7 @@ VkBuffer::VkBuffer(NonNullPtr<VkGPUContext> ctx, VkAllocator& allocator, const B
         // Needs to get its data from somewhere. Will therefore always need a transfer dest usage
         bufferUsage |= ::vk::BufferUsageFlagBits::eTransferDst;
     }
-    
+
     const bool needsConcurrent = ctx->queueFamilyIndices.size() > 1;
     buffer = VEX_VK_CHECK <<= ctx->device.createBufferUnique(::vk::BufferCreateInfo{
         .size = desc.byteSize,
@@ -113,6 +118,12 @@ void VkBuffer::AllocateBindlessHandle(RHIDescriptorPool& descriptorPool,
 ::vk::Buffer VkBuffer::GetNativeBuffer()
 {
     return *buffer;
+}
+
+::vk::DeviceAddress VkBuffer::GetDeviceAddress() const
+{
+    ::vk::BufferDeviceAddressInfo info{ .buffer = *buffer };
+    return VEX_VK_CHECK <<= ctx->device.getBufferAddress(info);
 }
 
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkBuffer.cpp
+++ b/src/Vulkan/RHI/VkBuffer.cpp
@@ -16,8 +16,7 @@ namespace vex::vk
 static ::vk::BufferUsageFlags GetVkBufferUsageFromDesc(const BufferDesc& desc)
 {
     using enum ::vk::BufferUsageFlagBits;
-    // TODO: Figure out implication of eAccelerationStructureBuildInputReadOnlyKHR needed when uploading to AS
-    ::vk::BufferUsageFlags flags = eTransferSrc | eShaderDeviceAddress | eAccelerationStructureBuildInputReadOnlyKHR;
+    ::vk::BufferUsageFlags flags = eTransferSrc | eShaderDeviceAddress;
     if (desc.usage & BufferUsage::ShaderReadUniform)
     {
         flags |= eUniformBuffer;
@@ -45,6 +44,10 @@ static ::vk::BufferUsageFlags GetVkBufferUsageFromDesc(const BufferDesc& desc)
     if (desc.usage & BufferUsage::ShaderTable)
     {
         flags |= eShaderBindingTableKHR;
+    }
+    if (desc.usage & BufferUsage::BuildAccelerationStructure)
+    {
+        flags |= eAccelerationStructureBuildInputReadOnlyKHR;
     }
     return flags;
 }

--- a/src/Vulkan/RHI/VkBuffer.h
+++ b/src/Vulkan/RHI/VkBuffer.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
-#include <Vex/Utility/NonNullPtr.h>
 #include <Vex/Types.h>
+#include <Vex/Utility/NonNullPtr.h>
 
 #include <RHI/RHIAllocator.h>
 #include <RHI/RHIBuffer.h>
@@ -29,6 +29,7 @@ public:
                                 BindlessHandle handle,
                                 const BufferViewDesc& desc) override;
     ::vk::Buffer GetNativeBuffer();
+    ::vk::DeviceAddress GetDeviceAddress() const;
 
 private:
     NonNullPtr<VkGPUContext> ctx;

--- a/src/Vulkan/RHI/VkCommandList.cpp
+++ b/src/Vulkan/RHI/VkCommandList.cpp
@@ -12,6 +12,7 @@
 #include <RHI/RHIBindings.h>
 #include <RHI/RHIPhysicalDevice.h>
 
+#include <Vulkan/RHI/VkAccelerationStructure.h>
 #include <Vulkan/RHI/VkBarrier.h>
 #include <Vulkan/RHI/VkBuffer.h>
 #include <Vulkan/RHI/VkDescriptorPool.h>
@@ -131,7 +132,7 @@ void VkCommandList::SetPipelineState(const RHIComputePipelineState& computePipel
 
 void VkCommandList::SetPipelineState(const RHIRayTracingPipelineState& rayTracingPipelineState)
 {
-    VEX_NOT_YET_IMPLEMENTED();
+    commandBuffer->bindPipeline(::vk::PipelineBindPoint::eRayTracingKHR, *rayTracingPipelineState.rtPipeline);
 }
 
 void VkCommandList::SetLayout(RHIResourceLayout& layout)
@@ -144,7 +145,8 @@ void VkCommandList::SetLayout(RHIResourceLayout& layout)
 
     // Stage flags must be the same as the push constant ranges defined in the layout
     commandBuffer->pushConstants(*layout.pipelineLayout,
-                                 ::vk::ShaderStageFlagBits::eAllGraphics | ::vk::ShaderStageFlagBits::eCompute,
+                                 ::vk::ShaderStageFlagBits::eAllGraphics | ::vk::ShaderStageFlagBits::eCompute |
+                                     ::vk::ShaderStageFlagBits::eRaygenKHR,
                                  0,
                                  localConstantsData.size(),
                                  localConstantsData.data());
@@ -166,6 +168,13 @@ void VkCommandList::SetDescriptorPool(RHIDescriptorPool& descriptorPool, RHIReso
                                           nullptr);
     case QueueTypes::Compute:
         commandBuffer->bindDescriptorSets(::vk::PipelineBindPoint::eCompute,
+                                          *resourceLayout.pipelineLayout,
+                                          0,
+                                          descriptorSets.size(),
+                                          descriptorSets.data(),
+                                          0,
+                                          nullptr);
+        commandBuffer->bindDescriptorSets(::vk::PipelineBindPoint::eRayTracingKHR,
                                           *resourceLayout.pipelineLayout,
                                           0,
                                           descriptorSets.size(),
@@ -521,7 +530,28 @@ void VkCommandList::Dispatch(const std::array<u32, 3>& groupCount)
 void VkCommandList::TraceRays(const TraceRaysDesc& rayTracingArgs,
                               const RHIRayTracingPipelineState& rayTracingPipelineState)
 {
-    VEX_NOT_YET_IMPLEMENTED();
+    ::vk::StridedDeviceAddressRegionKHR rayGenAddress{}, rayMissAddress{}, hitGroupAddress{}, callableAddress{};
+
+    if (rayTracingPipelineState.rayGenTable)
+        rayGenAddress = rayTracingPipelineState.rayGenTable->GetDeviceRegion(rayTracingArgs.rayGenShaderIndex);
+
+    if (rayTracingPipelineState.rayMissTable)
+        rayMissAddress = rayTracingPipelineState.rayMissTable->GetDeviceRegion(rayTracingArgs.rayMissShaderIndex);
+
+    if (rayTracingPipelineState.groupHitTable)
+        hitGroupAddress = rayTracingPipelineState.groupHitTable->GetDeviceRegion(rayTracingArgs.hitGroupShaderIndex);
+
+    if (rayTracingPipelineState.rayCallableTable)
+        callableAddress =
+            rayTracingPipelineState.rayCallableTable->GetDeviceRegion(rayTracingArgs.rayCallableShaderIndex);
+
+    commandBuffer->traceRaysKHR(rayGenAddress,
+                                rayMissAddress,
+                                hitGroupAddress,
+                                callableAddress,
+                                rayTracingArgs.width,
+                                rayTracingArgs.height,
+                                rayTracingArgs.depth);
 }
 
 void VkCommandList::GenerateMips(RHITexture& texture, const TextureSubresource& subresource)
@@ -621,7 +651,18 @@ void VkCommandList::ResolveTimestampQueries(u32 firstQuery, u32 queryCount)
 
 void VkCommandList::BuildBLAS(RHIAccelerationStructure& as, RHIBuffer& scratchBuffer)
 {
-    VEX_NOT_YET_IMPLEMENTED();
+    ::vk::AccelerationStructureBuildGeometryInfoKHR asBuildInfo{
+        .type = ::vk::AccelerationStructureTypeKHR::eBottomLevel,
+        .flags = ASBuildFlagsToVkASBuildFlags(as.GetDesc().buildFlags),
+        .mode = ::vk::BuildAccelerationStructureModeKHR::eBuild,
+        .geometryCount = static_cast<u32>(as.geometries.size()),
+        .pGeometries = as.geometries.data(),
+    };
+
+    asBuildInfo.dstAccelerationStructure = *as.vkAccelerationStructure;
+    asBuildInfo.scratchData.deviceAddress = scratchBuffer.GetDeviceAddress();
+
+    commandBuffer->buildAccelerationStructuresKHR({ asBuildInfo }, { as.ranges.data() });
 }
 
 void VkCommandList::BuildTLAS(RHIAccelerationStructure& as,
@@ -629,7 +670,18 @@ void VkCommandList::BuildTLAS(RHIAccelerationStructure& as,
                               RHIBuffer& uploadBuffer,
                               const RHITLASBuildDesc& desc)
 {
-    VEX_NOT_YET_IMPLEMENTED();
+    ::vk::AccelerationStructureBuildGeometryInfoKHR asBuildInfo{
+        .type = ::vk::AccelerationStructureTypeKHR::eTopLevel,
+        .flags = ASBuildFlagsToVkASBuildFlags(as.GetDesc().buildFlags),
+        .mode = ::vk::BuildAccelerationStructureModeKHR::eBuild,
+        .geometryCount = static_cast<u32>(as.geometries.size()),
+        .pGeometries = as.geometries.data(),
+    };
+
+    asBuildInfo.dstAccelerationStructure = *as.vkAccelerationStructure;
+    asBuildInfo.scratchData.deviceAddress = scratchBuffer.GetDeviceAddress();
+
+    commandBuffer->buildAccelerationStructuresKHR({ asBuildInfo }, { as.ranges.data() });
 }
 
 void VkCommandList::Copy(RHITexture& src, RHITexture& dst, Span<const TextureCopyDesc> textureCopyDescriptions)

--- a/src/Vulkan/RHI/VkPhysicalDevice.cpp
+++ b/src/Vulkan/RHI/VkPhysicalDevice.cpp
@@ -67,7 +67,6 @@ bool VkPhysicalDevice::IsFeatureSupported(Feature feature) const
     case Feature::MeshShader:
         return meshShaderFeatures.meshShader && meshShaderFeatures.taskShader;
     case Feature::RayTracing:
-        // Vulkan RHI currently does not support ray tracing.
         return rayTracingFeatures.rayTracingPipeline;
     default:
         VEX_LOG(Fatal, "Unable to determine feature support for {}", feature);

--- a/src/Vulkan/RHI/VkPhysicalDevice.cpp
+++ b/src/Vulkan/RHI/VkPhysicalDevice.cpp
@@ -68,7 +68,7 @@ bool VkPhysicalDevice::IsFeatureSupported(Feature feature) const
         return meshShaderFeatures.meshShader && meshShaderFeatures.taskShader;
     case Feature::RayTracing:
         // Vulkan RHI currently does not support ray tracing.
-        return false && rayTracingFeatures.rayTracingPipeline;
+        return rayTracingFeatures.rayTracingPipeline;
     default:
         VEX_LOG(Fatal, "Unable to determine feature support for {}", feature);
         return false;

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -269,7 +269,7 @@ VkRayTracingPipelineState::VkRayTracingPipelineState(const Key& key,
                                                      ::vk::PipelineCache PSOCache)
     : RHIRayTracingPipelineStateBase(key)
     , ctx{ ctx }
-    , PSOCache{ PSOCache }
+    , psoCache{ PSOCache }
 {
 }
 
@@ -371,7 +371,7 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
         .maxPipelineRayRecursionDepth = key.maxRecursionDepth,
         .layout = *resourceLayout.pipelineLayout,
     };
-    rtPipeline = VEX_VK_CHECK <<= ctx->device.createRayTracingPipelineKHRUnique({}, PSOCache, rtPSOCI);
+    rtPipeline = VEX_VK_CHECK <<= ctx->device.createRayTracingPipelineKHRUnique({}, psoCache, rtPSOCI);
 
     auto ASProperties =
         GPhysicalDevice->physicalDevice
@@ -460,7 +460,7 @@ std::unique_ptr<RHIRayTracingPipelineState> VkRayTracingPipelineState::Cleanup()
     {
         return nullptr;
     }
-    auto cleanupPSO = std::make_unique<VkRayTracingPipelineState>(key, ctx, PSOCache);
+    auto cleanupPSO = std::make_unique<VkRayTracingPipelineState>(key, ctx, psoCache);
     std::swap(cleanupPSO->rtPipeline, rtPipeline);
     return cleanupPSO;
 }

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include <Vex/ResourceCleanup.h>
+#include <Vex/PhysicalDevice.h>
 
 #include <Vulkan/RHI/VkAccelerationStructure.h>
 #include <Vulkan/RHI/VkBuffer.h>
@@ -11,6 +12,10 @@
 #include <Vulkan/VkDebug.h>
 #include <Vulkan/VkErrorHandler.h>
 #include <Vulkan/VkFormats.h>
+#include <Vex/Utility/ByteUtils.h>
+// These are necessary for ResourceCleanup
+#include <Vulkan/RHI/VkBuffer.h>
+#include <Vulkan/RHI/VkTexture.h>
 #include <Vulkan/VkGraphicsPipeline.h>
 
 namespace vex::vk
@@ -260,27 +265,185 @@ std::unique_ptr<RHIComputePipelineState> VkComputePipelineState::Cleanup()
     return cleanupPSO;
 }
 
-VkRayTracingPipelineState::VkRayTracingPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache)
+VkRayTracingPipelineState::VkRayTracingPipelineState(const Key& key,
+                                                     NonNullPtr<VkGPUContext> ctx,
+                                                     ::vk::PipelineCache PSOCache)
     : RHIRayTracingPipelineStateBase(key)
+    , ctx{ ctx }
+    , PSOCache{ PSOCache }
 {
-    VEX_NOT_YET_IMPLEMENTED();
 }
 
 std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
     const RayTracingShaderCollection& shaderCollection, RHIResourceLayout& resourceLayout, RHIAllocator& allocator)
 {
-    VEX_NOT_YET_IMPLEMENTED();
-    return {};
+    auto createShaderModule = [&](const Shader& s)
+    {
+        Span<const byte> shaderCode = s.GetBlob();
+        ::vk::ShaderModuleCreateInfo shaderModulecreateInfo{
+            .codeSize = shaderCode.size(),
+            .pCode = reinterpret_cast<const u32*>(&shaderCode[0]),
+        };
+
+        return VEX_VK_CHECK <<= ctx->device.createShaderModuleUnique(shaderModulecreateInfo);
+    };
+
+    std::vector<::vk::UniqueShaderModule> modules;
+    std::vector<::vk::PipelineShaderStageCreateInfo> stages;
+    std::vector<::vk::RayTracingShaderGroupCreateInfoKHR> groups;
+
+    using VkShaderGroupCreateInfo = ::vk::RayTracingShaderGroupCreateInfoKHR;
+    auto registerShaderStage = [&](const std::vector<NonNullPtr<Shader>>& shaders,
+                                   ::vk::ShaderStageFlagBits type,
+                                   ::vk::RayTracingShaderGroupTypeKHR groupType,
+                                   uint32_t VkShaderGroupCreateInfo::* p)
+    {
+        for (u32 i = 0; i < shaders.size(); ++i)
+        {
+            modules.push_back(createShaderModule(*shaders[i]));
+
+            ::vk::RayTracingShaderGroupCreateInfoKHR group{
+                .type = groupType,
+            };
+            group.*p = stages.size();
+            groups.push_back(group);
+
+            stages.push_back({ .stage = type, .module = *modules.back(), .pName = shaders[i]->key.entryPoint.c_str() });
+        }
+    };
+
+    registerShaderStage(shaderCollection.rayGenerationShaders,
+                        ::vk::ShaderStageFlagBits::eRaygenKHR,
+                        ::vk::RayTracingShaderGroupTypeKHR::eGeneral,
+                        &::vk::RayTracingShaderGroupCreateInfoKHR::generalShader);
+    registerShaderStage(shaderCollection.rayCallableShaders,
+                        ::vk::ShaderStageFlagBits::eCallableKHR,
+                        ::vk::RayTracingShaderGroupTypeKHR::eGeneral,
+                        &::vk::RayTracingShaderGroupCreateInfoKHR::generalShader);
+    registerShaderStage(shaderCollection.rayMissShaders,
+                        ::vk::ShaderStageFlagBits::eMissKHR,
+                        ::vk::RayTracingShaderGroupTypeKHR::eGeneral,
+                        &::vk::RayTracingShaderGroupCreateInfoKHR::generalShader);
+
+    for (const auto& group : shaderCollection.hitGroupShaders)
+    {
+        auto groupType = ::vk::RayTracingShaderGroupTypeKHR::eTrianglesHitGroup;
+
+        u32 closesHitIndex = ::vk::ShaderUnusedKHR, anyHitIndex = ::vk::ShaderUnusedKHR,
+            intersectionIndex = ::vk::ShaderUnusedKHR;
+
+        closesHitIndex = modules.size();
+        modules.push_back(createShaderModule(*group.rayClosestHitShader));
+        stages.push_back({ .stage = ::vk::ShaderStageFlagBits::eClosestHitKHR,
+                           .module = *modules.back(),
+                           .pName = group.rayClosestHitShader->key.entryPoint.c_str() });
+
+        if (group.rayAnyHitShader)
+        {
+            anyHitIndex = modules.size();
+            modules.push_back(createShaderModule(**group.rayAnyHitShader));
+            stages.push_back({ .stage = ::vk::ShaderStageFlagBits::eAnyHitKHR,
+                               .module = *modules.back(),
+                               .pName = (*group.rayAnyHitShader)->key.entryPoint.c_str() });
+        }
+
+        if (group.rayIntersectionShader)
+        {
+            // the presence of an intersection shader requires procedural hit group for custom intersection logic
+            groupType = ::vk::RayTracingShaderGroupTypeKHR::eProceduralHitGroup;
+            intersectionIndex = modules.size();
+            modules.push_back(createShaderModule(**group.rayIntersectionShader));
+            stages.push_back({ .stage = ::vk::ShaderStageFlagBits::eIntersectionKHR,
+                               .module = *modules.back(),
+                               .pName = (*group.rayIntersectionShader)->key.entryPoint.c_str() });
+        }
+
+        groups.push_back(::vk::RayTracingShaderGroupCreateInfoKHR{ .type = groupType,
+                                                                   .closestHitShader = closesHitIndex,
+                                                                   .anyHitShader = anyHitIndex,
+                                                                   .intersectionShader = intersectionIndex });
+    }
+
+    ::vk::RayTracingPipelineCreateInfoKHR rtPSOCI{
+        .stageCount = static_cast<u32>(stages.size()),
+        .pStages = stages.data(),
+        .groupCount = static_cast<u32>(groups.size()),
+        .pGroups = groups.data(),
+        .maxPipelineRayRecursionDepth = key.maxRecursionDepth,
+        .layout = *resourceLayout.pipelineLayout,
+    };
+    rtPipeline = VEX_VK_CHECK <<= ctx->device.createRayTracingPipelineKHRUnique({}, PSOCache, rtPSOCI);
+
+    auto ASProperties =
+        GPhysicalDevice->physicalDevice
+            .getProperties2<::vk::PhysicalDeviceProperties2, ::vk::PhysicalDeviceRayTracingPipelinePropertiesKHR>()
+            .get<::vk::PhysicalDeviceRayTracingPipelinePropertiesKHR>();
+
+    u32 handleSize = ASProperties.shaderGroupHandleSize;
+
+    std::vector<std::byte> groupHandles;
+    u32 handlesSize = handleSize * groups.size();
+    groupHandles.resize(handlesSize);
+    // Buffer containing all handles for groups in pipeline
+    VEX_VK_CHECK << ctx->device.getRayTracingShaderGroupHandlesKHR(*rtPipeline,
+                                                                   0,
+                                                                   groups.size(),
+                                                                   handlesSize,
+                                                                   groupHandles.data());
+
+    // 0: raygen, 1: raymiss, 2: group (closest hit, any hit and intersect), 3: callable
+    std::array<std::vector<void*>, 4> handlesPerShaderType;
+    for (int i = 0; i < stages.size(); ++i)
+    {
+        void* handlePtr = groupHandles.data() + i * handleSize;
+        switch (stages[i].stage)
+        {
+        case ::vk::ShaderStageFlagBits::eRaygenKHR:
+            handlesPerShaderType[0].push_back(handlePtr);
+            break;
+        case ::vk::ShaderStageFlagBits::eMissKHR:
+            handlesPerShaderType[1].push_back(handlePtr);
+            break;
+        case ::vk::ShaderStageFlagBits::eClosestHitKHR:
+        case ::vk::ShaderStageFlagBits::eAnyHitKHR:
+        case ::vk::ShaderStageFlagBits::eIntersectionKHR:
+            handlesPerShaderType[2].push_back(handlePtr);
+            break;
+        case ::vk::ShaderStageFlagBits::eCallableKHR:
+            handlesPerShaderType[3].push_back(handlePtr);
+            break;
+        default:
+            VEX_ASSERT(false, "This should never be reached");
+        }
+    }
+
+    rayGenTable = VkShaderTable(ctx, allocator, "Ray Gen shader Table", handlesPerShaderType[0]);
+
+    if (!handlesPerShaderType[1].empty())
+    {
+        rayMissTable = VkShaderTable(ctx, allocator, "Ray Miss shader Table", handlesPerShaderType[1]);
+    }
+
+    if (!handlesPerShaderType[2].empty())
+    {
+        groupHitTable = VkShaderTable(ctx, allocator, "Group Hit shader Table", handlesPerShaderType[2]);
+    }
+
+    if (!handlesPerShaderType[3].empty())
+    {
+        rayCallableTable = VkShaderTable(ctx, allocator, "Ray Callable shader Table", handlesPerShaderType[3]);
+    }
 }
 
 std::unique_ptr<RHIRayTracingPipelineState> VkRayTracingPipelineState::Cleanup()
 {
-    // Don't cleanup if RTPSO is null.
-    if (!!1)
+    if (!rtPipeline)
     {
         return nullptr;
     }
-    VEX_NOT_YET_IMPLEMENTED();
+    auto cleanupPSO = MakeUnique<VkRayTracingPipelineState>(key, ctx, PSOCache);
+    std::swap(cleanupPSO->rtPipeline, rtPipeline);
+    resourceCleanup.CleanupResource(std::move(cleanupPSO));
 }
 
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -2,8 +2,9 @@
 
 #include <algorithm>
 
-#include <Vex/ResourceCleanup.h>
 #include <Vex/PhysicalDevice.h>
+#include <Vex/ResourceCleanup.h>
+#include <Vex/Utility/ByteUtils.h>
 
 #include <Vulkan/RHI/VkAccelerationStructure.h>
 #include <Vulkan/RHI/VkBuffer.h>
@@ -12,7 +13,6 @@
 #include <Vulkan/VkDebug.h>
 #include <Vulkan/VkErrorHandler.h>
 #include <Vulkan/VkFormats.h>
-#include <Vex/Utility/ByteUtils.h>
 // These are necessary for ResourceCleanup
 #include <Vulkan/RHI/VkBuffer.h>
 #include <Vulkan/RHI/VkTexture.h>
@@ -20,7 +20,6 @@
 
 namespace vex::vk
 {
-
 VkGraphicsPipelineState::VkGraphicsPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache)
     : RHIGraphicsPipelineStateBase(key)
     , device{ device }
@@ -417,6 +416,24 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
         }
     }
 
+    std::vector<MaybeUninitialized<RHIBuffer>> oldBuffers;
+    if (rayGenTable)
+    {
+        oldBuffers.push_back(std::move(rayGenTable->shaderTableBuffer));
+    }
+    if (rayMissTable)
+    {
+        oldBuffers.push_back(std::move(rayMissTable->shaderTableBuffer));
+    }
+    if (groupHitTable)
+    {
+        oldBuffers.push_back(std::move(groupHitTable->shaderTableBuffer));
+    }
+    if (rayCallableTable)
+    {
+        oldBuffers.push_back(std::move(rayCallableTable->shaderTableBuffer));
+    }
+
     rayGenTable = VkShaderTable(ctx, allocator, "Ray Gen shader Table", handlesPerShaderType[0]);
 
     if (!handlesPerShaderType[1].empty())
@@ -433,6 +450,8 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
     {
         rayCallableTable = VkShaderTable(ctx, allocator, "Ray Callable shader Table", handlesPerShaderType[3]);
     }
+
+    return oldBuffers;
 }
 
 std::unique_ptr<RHIRayTracingPipelineState> VkRayTracingPipelineState::Cleanup()
@@ -441,9 +460,9 @@ std::unique_ptr<RHIRayTracingPipelineState> VkRayTracingPipelineState::Cleanup()
     {
         return nullptr;
     }
-    auto cleanupPSO = MakeUnique<VkRayTracingPipelineState>(key, ctx, PSOCache);
+    auto cleanupPSO = std::make_unique<VkRayTracingPipelineState>(key, ctx, PSOCache);
     std::swap(cleanupPSO->rtPipeline, rtPipeline);
-    resourceCleanup.CleanupResource(std::move(cleanupPSO));
+    return cleanupPSO;
 }
 
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -276,7 +276,7 @@ VkRayTracingPipelineState::VkRayTracingPipelineState(const Key& key,
 std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
     const RayTracingShaderCollection& shaderCollection, RHIResourceLayout& resourceLayout, RHIAllocator& allocator)
 {
-    auto createShaderModule = [&](const Shader& s)
+    auto CreateShaderModule = [&](const Shader& s)
     {
         Span<const byte> shaderCode = s.GetBlob();
         ::vk::ShaderModuleCreateInfo shaderModulecreateInfo{
@@ -299,7 +299,7 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
     {
         for (u32 i = 0; i < shaders.size(); ++i)
         {
-            modules.push_back(createShaderModule(*shaders[i]));
+            modules.push_back(CreateShaderModule(*shaders[i]));
 
             ::vk::RayTracingShaderGroupCreateInfoKHR group{
                 .type = groupType,
@@ -332,7 +332,7 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
             intersectionIndex = ::vk::ShaderUnusedKHR;
 
         closesHitIndex = modules.size();
-        modules.push_back(createShaderModule(*group.rayClosestHitShader));
+        modules.push_back(CreateShaderModule(*group.rayClosestHitShader));
         stages.push_back({ .stage = ::vk::ShaderStageFlagBits::eClosestHitKHR,
                            .module = *modules.back(),
                            .pName = group.rayClosestHitShader->key.entryPoint.c_str() });
@@ -340,7 +340,7 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
         if (group.rayAnyHitShader)
         {
             anyHitIndex = modules.size();
-            modules.push_back(createShaderModule(**group.rayAnyHitShader));
+            modules.push_back(CreateShaderModule(**group.rayAnyHitShader));
             stages.push_back({ .stage = ::vk::ShaderStageFlagBits::eAnyHitKHR,
                                .module = *modules.back(),
                                .pName = (*group.rayAnyHitShader)->key.entryPoint.c_str() });
@@ -351,7 +351,7 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
             // the presence of an intersection shader requires procedural hit group for custom intersection logic
             groupType = ::vk::RayTracingShaderGroupTypeKHR::eProceduralHitGroup;
             intersectionIndex = modules.size();
-            modules.push_back(createShaderModule(**group.rayIntersectionShader));
+            modules.push_back(CreateShaderModule(**group.rayIntersectionShader));
             stages.push_back({ .stage = ::vk::ShaderStageFlagBits::eIntersectionKHR,
                                .module = *modules.back(),
                                .pName = (*group.rayIntersectionShader)->key.entryPoint.c_str() });

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -20,10 +20,10 @@
 
 namespace vex::vk
 {
-VkGraphicsPipelineState::VkGraphicsPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache)
+VkGraphicsPipelineState::VkGraphicsPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache psoCache)
     : RHIGraphicsPipelineStateBase(key)
     , device{ device }
-    , PSOCache{ PSOCache }
+    , psoCache{ psoCache }
 {
     GraphicsPiplineUtils::ValidateGraphicsPipeline(key);
 }
@@ -198,7 +198,7 @@ void VkGraphicsPipelineState::Compile(const Shader& vertexShader,
                                                          .basePipelineHandle = nullptr,
                                                          .basePipelineIndex = -1 };
 
-    graphicsPipeline = VEX_VK_CHECK <<= device.createGraphicsPipelineUnique(PSOCache, graphicsPipelineCI);
+    graphicsPipeline = VEX_VK_CHECK <<= device.createGraphicsPipelineUnique(psoCache, graphicsPipelineCI);
 
     vertexShaderVersion = vertexShader.version;
     pixelShaderVersion = pixelShader.version;
@@ -213,15 +213,15 @@ std::unique_ptr<RHIGraphicsPipelineState> VkGraphicsPipelineState::Cleanup()
     {
         return nullptr;
     }
-    auto cleanupPSO = std::make_unique<VkGraphicsPipelineState>(key, device, PSOCache);
+    auto cleanupPSO = std::make_unique<VkGraphicsPipelineState>(key, device, psoCache);
     std::swap(cleanupPSO->graphicsPipeline, graphicsPipeline);
     return cleanupPSO;
 }
 
-VkComputePipelineState::VkComputePipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache)
+VkComputePipelineState::VkComputePipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache psoCache)
     : RHIComputePipelineStateBase(key)
     , device{ device }
-    , PSOCache{ PSOCache }
+    , psoCache{ psoCache }
 {
 }
 
@@ -245,7 +245,7 @@ void VkComputePipelineState::Compile(const Shader& computeShader, RHIResourceLay
         .layout = *resourceLayout.pipelineLayout,
     };
 
-    computePipeline = VEX_VK_CHECK <<= device.createComputePipelineUnique(PSOCache, computePipelineCreateInfo);
+    computePipeline = VEX_VK_CHECK <<= device.createComputePipelineUnique(psoCache, computePipelineCreateInfo);
 
     computeShaderVersion = computeShader.version;
     rootSignatureVersion = resourceLayout.version;
@@ -259,17 +259,17 @@ std::unique_ptr<RHIComputePipelineState> VkComputePipelineState::Cleanup()
     {
         return nullptr;
     }
-    auto cleanupPSO = std::make_unique<VkComputePipelineState>(key, device, PSOCache);
+    auto cleanupPSO = std::make_unique<VkComputePipelineState>(key, device, psoCache);
     std::swap(cleanupPSO->computePipeline, computePipeline);
     return cleanupPSO;
 }
 
 VkRayTracingPipelineState::VkRayTracingPipelineState(const Key& key,
                                                      NonNullPtr<VkGPUContext> ctx,
-                                                     ::vk::PipelineCache PSOCache)
+                                                     ::vk::PipelineCache psoCache)
     : RHIRayTracingPipelineStateBase(key)
     , ctx{ ctx }
-    , psoCache{ PSOCache }
+    , psoCache{ psoCache }
 {
 }
 
@@ -292,7 +292,7 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
     std::vector<::vk::RayTracingShaderGroupCreateInfoKHR> groups;
 
     using VkShaderGroupCreateInfo = ::vk::RayTracingShaderGroupCreateInfoKHR;
-    auto registerShaderStage = [&](const std::vector<NonNullPtr<Shader>>& shaders,
+    auto RegisterShaderStage = [&](const std::vector<NonNullPtr<Shader>>& shaders,
                                    ::vk::ShaderStageFlagBits type,
                                    ::vk::RayTracingShaderGroupTypeKHR groupType,
                                    uint32_t VkShaderGroupCreateInfo::* p)
@@ -311,15 +311,15 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
         }
     };
 
-    registerShaderStage(shaderCollection.rayGenerationShaders,
+    RegisterShaderStage(shaderCollection.rayGenerationShaders,
                         ::vk::ShaderStageFlagBits::eRaygenKHR,
                         ::vk::RayTracingShaderGroupTypeKHR::eGeneral,
                         &::vk::RayTracingShaderGroupCreateInfoKHR::generalShader);
-    registerShaderStage(shaderCollection.rayCallableShaders,
+    RegisterShaderStage(shaderCollection.rayCallableShaders,
                         ::vk::ShaderStageFlagBits::eCallableKHR,
                         ::vk::RayTracingShaderGroupTypeKHR::eGeneral,
                         &::vk::RayTracingShaderGroupCreateInfoKHR::generalShader);
-    registerShaderStage(shaderCollection.rayMissShaders,
+    RegisterShaderStage(shaderCollection.rayMissShaders,
                         ::vk::ShaderStageFlagBits::eMissKHR,
                         ::vk::RayTracingShaderGroupTypeKHR::eGeneral,
                         &::vk::RayTracingShaderGroupCreateInfoKHR::generalShader);
@@ -381,13 +381,13 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
     u32 handleSize = ASProperties.shaderGroupHandleSize;
 
     std::vector<std::byte> groupHandles;
-    u32 handlesSize = handleSize * groups.size();
-    groupHandles.resize(handlesSize);
+    u32 totalHandlesByteSize = handleSize * groups.size();
+    groupHandles.resize(totalHandlesByteSize);
     // Buffer containing all handles for groups in pipeline
     VEX_VK_CHECK << ctx->device.getRayTracingShaderGroupHandlesKHR(*rtPipeline,
                                                                    0,
                                                                    groups.size(),
-                                                                   handlesSize,
+                                                                   totalHandlesByteSize,
                                                                    groupHandles.data());
 
     // 0: raygen, 1: raymiss, 2: group (closest hit, any hit and intersect), 3: callable
@@ -462,6 +462,12 @@ std::unique_ptr<RHIRayTracingPipelineState> VkRayTracingPipelineState::Cleanup()
     }
     auto cleanupPSO = std::make_unique<VkRayTracingPipelineState>(key, ctx, psoCache);
     std::swap(cleanupPSO->rtPipeline, rtPipeline);
+
+    std::swap(cleanupPSO->groupHitTable, groupHitTable);
+    std::swap(cleanupPSO->rayCallableTable, rayCallableTable);
+    std::swap(cleanupPSO->rayGenTable, rayGenTable);
+    std::swap(cleanupPSO->rayMissTable, rayMissTable);
+
     return cleanupPSO;
 }
 

--- a/src/Vulkan/RHI/VkPipelineState.cpp
+++ b/src/Vulkan/RHI/VkPipelineState.cpp
@@ -456,18 +456,17 @@ std::vector<MaybeUninitialized<RHIBuffer>> VkRayTracingPipelineState::Compile(
 
 std::unique_ptr<RHIRayTracingPipelineState> VkRayTracingPipelineState::Cleanup()
 {
-    if (!rtPipeline)
+    if (!rtPipeline && !groupHitTable && !rayCallableTable && !rayGenTable && !rayMissTable)
     {
         return nullptr;
     }
+
     auto cleanupPSO = std::make_unique<VkRayTracingPipelineState>(key, ctx, psoCache);
     std::swap(cleanupPSO->rtPipeline, rtPipeline);
-
     std::swap(cleanupPSO->groupHitTable, groupHitTable);
     std::swap(cleanupPSO->rayCallableTable, rayCallableTable);
     std::swap(cleanupPSO->rayGenTable, rayGenTable);
     std::swap(cleanupPSO->rayMissTable, rayMissTable);
-
     return cleanupPSO;
 }
 

--- a/src/Vulkan/RHI/VkPipelineState.h
+++ b/src/Vulkan/RHI/VkPipelineState.h
@@ -30,7 +30,7 @@ public:
         return seed;
     });
 
-    VkGraphicsPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache);
+    VkGraphicsPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache psoCache);
     VkGraphicsPipelineState(VkGraphicsPipelineState&&) = default;
     VkGraphicsPipelineState& operator=(VkGraphicsPipelineState&&) = default;
     virtual void Compile(const Shader& vertexShader,
@@ -42,13 +42,13 @@ public:
 
 private:
     ::vk::Device device;
-    ::vk::PipelineCache PSOCache;
+    ::vk::PipelineCache psoCache;
 };
 
 class VkComputePipelineState final : public RHIComputePipelineStateBase
 {
 public:
-    VkComputePipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache);
+    VkComputePipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache psoCache);
     VkComputePipelineState(VkComputePipelineState&&) = default;
     VkComputePipelineState& operator=(VkComputePipelineState&&) = default;
     virtual void Compile(const Shader& computeShader, RHIResourceLayout& resourceLayout) override;
@@ -58,13 +58,13 @@ public:
 
 private:
     ::vk::Device device;
-    ::vk::PipelineCache PSOCache;
+    ::vk::PipelineCache psoCache;
 };
 
 class VkRayTracingPipelineState final : public RHIRayTracingPipelineStateBase
 {
 public:
-    VkRayTracingPipelineState(const Key& key, NonNullPtr<VkGPUContext> ctx, ::vk::PipelineCache PSOCache);
+    VkRayTracingPipelineState(const Key& key, NonNullPtr<VkGPUContext> ctx, ::vk::PipelineCache psoCache);
     VkRayTracingPipelineState(VkRayTracingPipelineState&&) = default;
     VkRayTracingPipelineState& operator=(VkRayTracingPipelineState&&) = default;
     virtual std::vector<MaybeUninitialized<RHIBuffer>> Compile(const RayTracingShaderCollection& shaderCollection,

--- a/src/Vulkan/RHI/VkPipelineState.h
+++ b/src/Vulkan/RHI/VkPipelineState.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <Vex/Utility/MaybeUninitialized.h>
+
 #include <RHI/RHIPipelineState.h>
 
+#include <Vulkan/RHI/VkShaderTable.h>
+#include <Vulkan/VkGPUContext.h>
 #include <Vulkan/VkHeaders.h>
 
 namespace vex::vk
@@ -60,13 +64,24 @@ private:
 class VkRayTracingPipelineState final : public RHIRayTracingPipelineStateBase
 {
 public:
-    VkRayTracingPipelineState(const Key& key, ::vk::Device device, ::vk::PipelineCache PSOCache);
+    VkRayTracingPipelineState(const Key& key, NonNullPtr<VkGPUContext> ctx, ::vk::PipelineCache PSOCache);
     VkRayTracingPipelineState(VkRayTracingPipelineState&&) = default;
     VkRayTracingPipelineState& operator=(VkRayTracingPipelineState&&) = default;
     virtual std::vector<MaybeUninitialized<RHIBuffer>> Compile(const RayTracingShaderCollection& shaderCollection,
                                                                RHIResourceLayout& resourceLayout,
                                                                RHIAllocator& allocator) override;
     virtual std::unique_ptr<RHIRayTracingPipelineState> Cleanup() override;
+
+    ::vk::UniquePipeline rtPipeline;
+
+    MaybeUninitialized<VkShaderTable> rayGenTable;
+    MaybeUninitialized<VkShaderTable> rayMissTable;
+    MaybeUninitialized<VkShaderTable> groupHitTable;
+    MaybeUninitialized<VkShaderTable> rayCallableTable;
+
+private:
+    NonNullPtr<VkGPUContext> ctx;
+    ::vk::PipelineCache PSOCache;
 };
 
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkPipelineState.h
+++ b/src/Vulkan/RHI/VkPipelineState.h
@@ -81,7 +81,7 @@ public:
 
 private:
     NonNullPtr<VkGPUContext> ctx;
-    ::vk::PipelineCache PSOCache;
+    ::vk::PipelineCache psoCache;
 };
 
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -348,10 +348,25 @@ void VkRHI::Init()
     ValidateAndAddExtension(VK_GOOGLE_HLSL_FUNCTIONALITY1_EXTENSION_NAME);
     ValidateAndAddExtension(VK_KHR_UNIFIED_IMAGE_LAYOUTS_EXTENSION_NAME);
 
+    std::optional<::vk::PhysicalDeviceAccelerationStructureFeaturesKHR> featuresAccelerationStructure;
+    std::optional<::vk::PhysicalDeviceRayTracingPipelineFeaturesKHR> featuresRayTracingPipeline;
+    std::optional<::vk::PhysicalDeviceRayQueryFeaturesKHR> featuresRayQuery;
     if (GPhysicalDevice->IsFeatureSupported(Feature::RayTracing))
     {
         ValidateAndAddExtension(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
         ValidateAndAddExtension(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+        ValidateAndAddExtension(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+        ValidateAndAddExtension(VK_KHR_RAY_QUERY_EXTENSION_NAME);
+
+        featuresRayTracingPipeline = { .rayTracingPipeline = true };
+
+        featuresRayQuery = { .pNext = &*featuresRayTracingPipeline, .rayQuery = true };
+
+        featuresAccelerationStructure = {
+            .pNext = &*featuresRayQuery,
+            .accelerationStructure = true,
+            .descriptorBindingAccelerationStructureUpdateAfterBind = true,
+        };
     }
 
     // TODO(https://trello.com/c/rLevCOvT): vulkan ray tracing add required features
@@ -510,7 +525,7 @@ RHIComputePipelineState VkRHI::CreateComputePipelineState(const ComputePipelineS
 
 RHIRayTracingPipelineState VkRHI::CreateRayTracingPipelineState(const RayTracingPipelineStateKey& key)
 {
-    return { key, *device, *PSOCache };
+    return { key, GetGPUContext(), *PSOCache };
 }
 
 RHIResourceLayout VkRHI::CreateResourceLayout(RHIDescriptorPool& descriptorPool)
@@ -545,9 +560,7 @@ RHITimestampQueryPool VkRHI::CreateTimestampQueryPool(RHIAllocator& allocator)
 
 RHIAccelerationStructure VkRHI::CreateAS(const ASDesc& desc)
 {
-    // TODO(https://trello.com/c/rLevCOvT): Implement vulkan AS upload/creation.
-    VEX_NOT_YET_IMPLEMENTED();
-    return VkAccelerationStructure(desc);
+    return { GetGPUContext(), desc };
 }
 
 ::vk::Instance VkRHI::GetNativeInstance()

--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -370,7 +370,7 @@ void VkRHI::Init()
     }
 
     ::vk::PhysicalDeviceUnifiedImageLayoutsFeaturesKHR featuresUnifiedImageLayouts;
-    featuresUnifiedImageLayouts.pNext = &featuresAccelerationStructure;
+    featuresUnifiedImageLayouts.pNext = featuresAccelerationStructure ? &featuresAccelerationStructure : nullptr;
     featuresUnifiedImageLayouts.unifiedImageLayouts = true;
 
     // Allows for mutable descriptors

--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -369,9 +369,6 @@ void VkRHI::Init()
         };
     }
 
-    // TODO(https://trello.com/c/rLevCOvT): vulkan ray tracing add required features
-    ::vk::PhysicalDeviceAccelerationStructureFeaturesKHR featuresAccelerationStructure;
-
     ::vk::PhysicalDeviceUnifiedImageLayoutsFeaturesKHR featuresUnifiedImageLayouts;
     featuresUnifiedImageLayouts.pNext = &featuresAccelerationStructure;
     featuresUnifiedImageLayouts.unifiedImageLayouts = true;

--- a/src/Vulkan/RHI/VkResourceLayout.cpp
+++ b/src/Vulkan/RHI/VkResourceLayout.cpp
@@ -33,8 +33,9 @@ const VkDescriptorSet& VkResourceLayout::GetSamplerDescriptor()
 
 ::vk::UniquePipelineLayout VkResourceLayout::CreateLayout()
 {
-    ::vk::PushConstantRange range{ .stageFlags =
-                                       ::vk::ShaderStageFlagBits::eAllGraphics | ::vk::ShaderStageFlagBits::eCompute,
+    ::vk::PushConstantRange range{ .stageFlags = ::vk::ShaderStageFlagBits::eAllGraphics |
+                                                 ::vk::ShaderStageFlagBits::eCompute |
+                                                 ::vk::ShaderStageFlagBits::eRaygenKHR,
                                    .offset = 0,
                                    .size = GPhysicalDevice->GetMaxLocalConstantsByteSize() };
 

--- a/src/Vulkan/RHI/VkShaderTable.cpp
+++ b/src/Vulkan/RHI/VkShaderTable.cpp
@@ -10,13 +10,13 @@ VkShaderTable::VkShaderTable(NonNullPtr<VkGPUContext> ctx,
                              std::string_view name,
                              Span<void*> shaderHandles)
 {
-    auto ASProperties =
+    auto asProperties =
         ctx->physDevice
             .getProperties2<::vk::PhysicalDeviceProperties2, ::vk::PhysicalDeviceRayTracingPipelinePropertiesKHR>()
             .get<::vk::PhysicalDeviceRayTracingPipelinePropertiesKHR>();
 
-    entrySize = ASProperties.shaderGroupBaseAlignment;
-    auto handleSize = ASProperties.shaderGroupHandleSize;
+    entrySize = asProperties.shaderGroupBaseAlignment;
+    auto handleSize = asProperties.shaderGroupHandleSize;
 
     auto bufferDesc = BufferDesc::CreateStagingBufferDesc(std::string(name),
                                                           entrySize * shaderHandles.size(),

--- a/src/Vulkan/RHI/VkShaderTable.cpp
+++ b/src/Vulkan/RHI/VkShaderTable.cpp
@@ -1,0 +1,49 @@
+﻿#include "VkShaderTable.h"
+
+#include <Vulkan/VkGPUContext.h>
+
+namespace vex::vk
+{
+
+VkShaderTable::VkShaderTable(NonNullPtr<VkGPUContext> ctx,
+                             RHIAllocator& allocator,
+                             std::string_view name,
+                             Span<void*> shaderHandles)
+{
+    auto ASProperties =
+        ctx->physDevice
+            .getProperties2<::vk::PhysicalDeviceProperties2, ::vk::PhysicalDeviceRayTracingPipelinePropertiesKHR>()
+            .get<::vk::PhysicalDeviceRayTracingPipelinePropertiesKHR>();
+
+    entrySize = ASProperties.shaderGroupBaseAlignment;
+    auto handleSize = ASProperties.shaderGroupHandleSize;
+
+    auto bufferDesc = BufferDesc::CreateStagingBufferDesc(std::string(name),
+                                                          entrySize * shaderHandles.size(),
+                                                          BufferUsage::GenericBuffer | BufferUsage::ShaderTable);
+
+    shaderTableBuffer = RHIBuffer(ctx, allocator, bufferDesc);
+
+    auto mappedData = shaderTableBuffer->GetMappedData();
+
+    std::byte* dstPtr = mappedData.data();
+    std::uninitialized_fill_n(dstPtr, bufferDesc.byteSize, static_cast<std::byte>(0));
+
+    for (u32 i = 0; i < shaderHandles.size(); ++i)
+    {
+        auto* srcPtr = static_cast<std::byte*>(shaderHandles[i]);
+        std::uninitialized_copy_n(srcPtr, handleSize, dstPtr);
+        dstPtr += entrySize;
+    }
+}
+
+::vk::StridedDeviceAddressRegionKHR VkShaderTable::GetDeviceRegion(u32 tableIndex) const
+{
+    return {
+        .deviceAddress = shaderTableBuffer->GetDeviceAddress() + tableIndex * entrySize,
+        .stride = entrySize,
+        .size = entrySize,
+    };
+}
+
+} // namespace vex::vk

--- a/src/Vulkan/RHI/VkShaderTable.cpp
+++ b/src/Vulkan/RHI/VkShaderTable.cpp
@@ -20,7 +20,7 @@ VkShaderTable::VkShaderTable(NonNullPtr<VkGPUContext> ctx,
 
     auto bufferDesc = BufferDesc::CreateStagingBufferDesc(std::string(name),
                                                           entrySize * shaderHandles.size(),
-                                                          BufferUsage::GenericBuffer | BufferUsage::ShaderTable);
+                                                          BufferUsage::ShaderRead | BufferUsage::ShaderTable);
 
     shaderTableBuffer = RHIBuffer(ctx, allocator, bufferDesc);
 

--- a/src/Vulkan/RHI/VkShaderTable.h
+++ b/src/Vulkan/RHI/VkShaderTable.h
@@ -22,6 +22,8 @@ public:
 private:
     MaybeUninitialized<RHIBuffer> shaderTableBuffer;
     u32 entrySize;
+
+    friend class VkRayTracingPipelineState;
 };
 
 } // namespace vex::vk

--- a/src/Vulkan/RHI/VkShaderTable.h
+++ b/src/Vulkan/RHI/VkShaderTable.h
@@ -1,0 +1,27 @@
+﻿#pragma once
+#include <Vex/Containers/Span.h>
+
+#include <RHI/RHIFwd.h>
+
+#include <Vulkan/RHI/VkBuffer.h>
+
+namespace vex::vk
+{
+struct VkGPUContext;
+
+class VkShaderTable
+{
+public:
+    VkShaderTable(NonNullPtr<VkGPUContext> ctx,
+                  RHIAllocator& allocator,
+                  std::string_view name,
+                  Span<void*> shaderHandles);
+
+    ::vk::StridedDeviceAddressRegionKHR GetDeviceRegion(u32 tableIndex) const;
+
+private:
+    MaybeUninitialized<RHIBuffer> shaderTableBuffer;
+    u32 entrySize;
+};
+
+} // namespace vex::vk

--- a/src/Vulkan/RHI/VkTexture.cpp
+++ b/src/Vulkan/RHI/VkTexture.cpp
@@ -333,11 +333,21 @@ void VkTexture::CreateImage(RHIAllocator& allocator)
         .pViewFormats = possibleViewFormats.data(),
     };
 
+    ::vk::ImageCreateFlags flags = {};
+    if (useMutableFormat)
+    {
+        flags |= ::vk::ImageCreateFlagBits::eMutableFormat;
+    }
+    if (desc.type == TextureType::TextureCube)
+    {
+        flags |= ::vk::ImageCreateFlagBits::eCubeCompatible;
+    }
+
     const bool needsConcurrent = ctx->queueFamilyIndices.size() > 1;
     ::vk::ImageCreateInfo createInfo{
         .pNext = useMutableFormat ? &imageFormatList : nullptr,
         // TODO: Add cube eCubeCompatible to flags when type is cube
-        .flags = useMutableFormat ? ::vk::ImageCreateFlagBits::eMutableFormat : ::vk::ImageCreateFlags{},
+        .flags = flags,
         // Force the non-SRGB variant.
         .format = TextureFormatToVulkan(desc.format, false),
         .mipLevels = desc.mips,

--- a/src/Vulkan/RHI/VkTexture.cpp
+++ b/src/Vulkan/RHI/VkTexture.cpp
@@ -346,7 +346,6 @@ void VkTexture::CreateImage(RHIAllocator& allocator)
     const bool needsConcurrent = ctx->queueFamilyIndices.size() > 1;
     ::vk::ImageCreateInfo createInfo{
         .pNext = useMutableFormat ? &imageFormatList : nullptr,
-        // TODO: Add cube eCubeCompatible to flags when type is cube
         .flags = flags,
         // Force the non-SRGB variant.
         .format = TextureFormatToVulkan(desc.format, false),

--- a/src/Vulkan/RHI/VkTexture.cpp
+++ b/src/Vulkan/RHI/VkTexture.cpp
@@ -336,6 +336,7 @@ void VkTexture::CreateImage(RHIAllocator& allocator)
     const bool needsConcurrent = ctx->queueFamilyIndices.size() > 1;
     ::vk::ImageCreateInfo createInfo{
         .pNext = useMutableFormat ? &imageFormatList : nullptr,
+        // TODO: Add cube eCubeCompatible to flags when type is cube
         .flags = useMutableFormat ? ::vk::ImageCreateFlagBits::eMutableFormat : ::vk::ImageCreateFlags{},
         // Force the non-SRGB variant.
         .format = TextureFormatToVulkan(desc.format, false),

--- a/tests/AccelerationStructureTest.cpp
+++ b/tests/AccelerationStructureTest.cpp
@@ -606,8 +606,8 @@ TEST_P(ASAABBTest, CreateAABBTraceShader)
                          .entryPoint = "ClosestHitMain",
                          .type = ShaderType::RayClosestHitShader,
                      },
-                     .rayIntersectionShader =
-                     ShaderKey{
+                     .rayIntersectionShader = ShaderKey
+                     {
                           .path = shaderPath,
                           .entryPoint = "IntersectMain",
                           .type = ShaderType::RayIntersectionShader,
@@ -622,7 +622,7 @@ TEST_P(ASAABBTest, CreateAABBTraceShader)
         ConstantBinding(data),
         {binding},
         {
-            1, 1, 1
+            100, 100, 1
         }
     );
 

--- a/tests/AccelerationStructureTest.cpp
+++ b/tests/AccelerationStructureTest.cpp
@@ -21,12 +21,16 @@ struct AccelerationStructureTest : RTVexTest
 
         auto ctx = graphics.CreateCommandContext(QueueType::Compute);
 
-        const BufferDesc vbDesc =
-            BufferDesc::CreateVertexBufferDesc("RT Triangle Vertex Buffer", sizeof(Vertex) * TriangleVerts.size());
+        const BufferDesc vbDesc = BufferDesc::CreateVertexBufferDesc("RT Triangle Vertex Buffer",
+                                                                     sizeof(Vertex) * TriangleVerts.size(),
+                                                                     false,
+                                                                     true);
         triangleVertexBuffer = graphics.CreateBuffer(vbDesc);
 
-        const BufferDesc ibDesc =
-            BufferDesc::CreateIndexBufferDesc("RT Triangle Index Buffer", sizeof(u32) * TriangleIndices.size());
+        const BufferDesc ibDesc = BufferDesc::CreateIndexBufferDesc("RT Triangle Index Buffer",
+                                                                    sizeof(u32) * TriangleIndices.size(),
+                                                                    false,
+                                                                    true);
         triangleIndexBuffer = graphics.CreateBuffer(ibDesc);
 
         ctx.EnqueueDataUpload(triangleVertexBuffer, std::as_bytes(std::span(TriangleVerts)));

--- a/tests/RayTracingTest.cpp
+++ b/tests/RayTracingTest.cpp
@@ -36,12 +36,16 @@ struct RTTestFixture : public RTVexTest
             ASDesc{ .name = "Triangle TLAS", .type = ASType::TopLevel, .buildFlags = ASBuild::None });
 
         auto ctx = graphics.CreateCommandContext(QueueType::Compute);
-        const BufferDesc vbDesc =
-            BufferDesc::CreateVertexBufferDesc("RT Triangle Vertex Buffer", sizeof(Vertex) * TriangleVerts.size());
+        const BufferDesc vbDesc = BufferDesc::CreateVertexBufferDesc("RT Triangle Vertex Buffer",
+                                                                     sizeof(Vertex) * TriangleVerts.size(),
+                                                                     false,
+                                                                     true);
         triangleVertexBuffer = graphics.CreateBuffer(vbDesc);
 
-        const BufferDesc ibDesc =
-            BufferDesc::CreateIndexBufferDesc("RT Triangle Index Buffer", sizeof(u32) * TriangleIndices.size());
+        const BufferDesc ibDesc = BufferDesc::CreateIndexBufferDesc("RT Triangle Index Buffer",
+                                                                    sizeof(u32) * TriangleIndices.size(),
+                                                                    false,
+                                                                    true);
         triangleIndexBuffer = graphics.CreateBuffer(ibDesc);
 
         const BufferDesc outputDesc = BufferDesc::CreateGenericBufferDesc("RT Output Buffer", sizeof(float) * 3, true);

--- a/tests/shaders/RayTracingAABB.hlsl
+++ b/tests/shaders/RayTracingAABB.hlsl
@@ -8,9 +8,6 @@ struct UniformStruct
 
 VEX_UNIFORMS(UniformStruct, Uniforms);
 
-static RWStructuredBuffer<float> Output = GetBindlessResource(Uniforms.outputHandle);
-static RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
-
 struct HitAttributes
 {
     float2 dummy;
@@ -24,9 +21,9 @@ struct [raypayload] RayPayload
 [shader("raygeneration")]
 void RayGenMain()
 {
-    uint2 launchIndex = DispatchRaysIndex().xy;
-    uint2 launchDimensions = DispatchRaysDimensions().xy;
-    
+    RWStructuredBuffer<float> Output = GetBindlessResource(Uniforms.outputHandle);
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+
     RayDesc ray;
     ray.Direction = float3(0, 0, 1);
     ray.Origin = float3(0.5f, 0.5f, 0);

--- a/tests/shaders/RayTracingAABB.slang
+++ b/tests/shaders/RayTracingAABB.slang
@@ -1,5 +1,13 @@
 import Vex;
 
+struct UniformStruct
+{
+    uint outputHandle;
+    uint accelerationStructureHandle;
+};
+
+[vk::push_constant] uniform UniformStruct Uniforms;
+
 struct HitAttributes
 {
     float2 dummy;
@@ -11,12 +19,10 @@ struct [raypayload] RayPayload
 };
 
 [shader("raygeneration")]
-void RayGenMain(
-    uniform uint outputHandle,
-    uniform uint accelerationStructureHandle)
+void RayGenMain()
 {
-    let Output = GetBindlessResource<RWStructuredBuffer<float>>(outputHandle);
-    let AccelerationStructure = GetBindlessResource<RaytracingAccelerationStructure>(accelerationStructureHandle);
+    let Output = GetBindlessResource<RWStructuredBuffer<float>>(Uniforms.outputHandle);
+    let AccelerationStructure = GetBindlessResource<RaytracingAccelerationStructure>(Uniforms.accelerationStructureHandle);
 
     RayDesc ray;
     ray.Direction = float3(0, 0, 1);
@@ -42,18 +48,13 @@ void RayGenMain(
 }
 
 [shader("miss")]
-void MissMain(
-    uniform uint outputHandle,
-    uniform uint accelerationStructureHandle,
-    inout RayPayload payload)
+void MissMain(inout RayPayload payload)
 {
     payload.res = -1;
 }
 
 [shader("intersection")]
-void IntersectMain(
-    uniform uint outputHandle,
-    uniform uint accelerationStructureHandle)
+void IntersectMain()
 {
     float tHit = 0.8f;
     HitAttributes attr = (HitAttributes) 0;
@@ -61,11 +62,7 @@ void IntersectMain(
 }
 
 [shader("closesthit")]
-void ClosestHitMain(
-    uniform uint outputHandle,
-    uniform uint accelerationStructureHandle,
-    inout RayPayload payload,
-    in HitAttributes attr)
+void ClosestHitMain(inout RayPayload payload, in HitAttributes attr)
 {
     payload.res = 1;
 }

--- a/tests/shaders/RayTracingTest.hlsl
+++ b/tests/shaders/RayTracingTest.hlsl
@@ -8,9 +8,6 @@ struct UniformStruct
 
 VEX_UNIFORMS(UniformStruct, Uniforms);
 
-static RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
-static RWStructuredBuffer<float3> Output = GetBindlessResource(Uniforms.outputBufferHandle);
-
 struct HitAttributes
 {
     float2 barycentrics;
@@ -45,6 +42,9 @@ struct CallableData
 [shader("raygeneration")]
 void RayGenBasicMain()
 {
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+    RWStructuredBuffer<float3> Output = GetBindlessResource(Uniforms.outputBufferHandle);
+
     RayDesc ray;
     ray.Origin = float3(0, 0, 0);
     ray.Direction = float3(0, 0, 1);
@@ -77,6 +77,9 @@ void RayGenBasicMain()
 [shader("raygeneration")]
 void RayGenMain()
 {
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+    RWStructuredBuffer<float3> Output = GetBindlessResource(Uniforms.outputBufferHandle);
+
     RayDesc ray;
     ray.Origin = float3(0, 0, 0);
     ray.Direction = float3(0, 0, 1);
@@ -134,6 +137,9 @@ void RayGenMain()
 [shader("raygeneration")]
 void RayGenMainAlt()
 {
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+    RWStructuredBuffer<float3> Output = GetBindlessResource(Uniforms.outputBufferHandle);
+
     RayDesc ray;
     ray.Origin = float3(1, 1, 1);
     ray.Direction = float3(0, 0, -1);
@@ -170,6 +176,9 @@ void RayGenMainAlt()
 [shader("raygeneration")]
 void RayGenHitGroupSelectionMain()
 {
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+    RWStructuredBuffer<float3> Output = GetBindlessResource(Uniforms.outputBufferHandle);
+
     RayDesc ray;
     ray.Origin = float3(0, 0, 0);
     ray.Direction = float3(0, 0, 1);
@@ -232,6 +241,8 @@ void MissShadow(inout ShadowPayload payload)
 [shader("closesthit")]
 void ClosestHitMain(inout RayPayload payload, in HitAttributes attrib)
 {
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+
     payload.hitValue = 1;
 
     if (payload.depth < 3)
@@ -263,6 +274,8 @@ void ClosestHitMain(inout RayPayload payload, in HitAttributes attrib)
 [shader("closesthit")]
 void ClosestHitMainAlt(inout RayPayload payload, in HitAttributes attrib)
 {
+    RaytracingAccelerationStructure AccelerationStructure = GetBindlessResource(Uniforms.accelerationStructureHandle);
+
     payload.hitValue = 2;
 
     if (payload.depth < 2)


### PR DESCRIPTION
This PR implements hardware ray tracing in the Vulkan RHI. It should now have an equivalent feature set as DX12's implementation. Most of the changes are in VkAccelerationStructure, VkRayTracingPipelineState and CommandContext.

All of the RT tests pass without issues in both RHIs.

Some code is very similar from DX to VK but I think its not worth the hassle to combine them. Maybe in the future if the need rises. Let me know if you disagree and I'll combine some things. 