### PR TITLE
Concluded investigation for user's Linux installation Vex crashing

### DIFF
--- a/src/Vulkan/RHI/VkRHI.cpp
+++ b/src/Vulkan/RHI/VkRHI.cpp
@@ -449,6 +449,12 @@ void VkRHI::Init()
     device = VEX_VK_CHECK <<= physDevice.createDeviceUnique(deviceCreateInfo);
     GDispatcherLifetime.SetDevice(*device);
 
+    VEX_LOG(Info, "Created VK device with extensions:");
+    for (auto deviceExtension : extensions)
+    {
+        VEX_LOG(Info, "\t{}", deviceExtension);
+    }
+
     if (graphicsQueueFamily != -1)
     {
         queues[QueueTypes::Graphics] = VkCommandQueue{


### PR DESCRIPTION
The issue was a crash due to invalid installation of the VulkanSDK, env variables pointing to the validation layers weren't setup meaning vulkan crashes when attempting to read them.
Otherwise, this adds additional logging to the Vulkan RHI for device extensions to facilitate future debugging.